### PR TITLE
Adding Parser.ExpectUntil to guard against infinite loops

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Build
       run: dotnet build src --no-restore
     - name: Test
-      run: dotnet test src --no-build --verbosity normal
+      run: dotnet test src --no-build --verbosity normal --blame-hang --blame-hang-timeout 30s

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/BlockStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/BlockStatementTests.cs
@@ -1,0 +1,57 @@
+﻿using FluentAssertions;
+using Todl.Compiler.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Todl.Compiler.Tests.CodeAnalysis;
+
+public sealed partial class ParserTests
+{
+    [Fact]
+    public void TestParseBlockStatementBasic()
+    {
+        var inputText = @"
+            {
+                a = 1 + 2;
+                ++a;
+                b = a;
+            }
+            ";
+        var blockStatement = ParseStatement<BlockStatement>(inputText);
+
+        blockStatement.OpenBraceToken.Text.Should().Be("{");
+        blockStatement.OpenBraceToken.Kind.Should().Be(SyntaxKind.OpenBraceToken);
+
+        blockStatement.InnerStatements.Should().SatisfyRespectively(
+            _0 => _0.As<ExpressionStatement>().Should().NotBeNull(),
+            _1 => _1.As<ExpressionStatement>().Should().NotBeNull(),
+            _2 => _2.As<ExpressionStatement>().Should().NotBeNull());
+
+        blockStatement.CloseBraceToken.Text.Should().Be("}");
+        blockStatement.CloseBraceToken.Kind.Should().Be(SyntaxKind.CloseBraceToken);
+    }
+
+    [Fact]
+    public void TestParseBlockStatementWithoutClosingBracket()
+    {
+        var inputText = @"
+            {
+                a = 1 + 2;
+                ++a;
+                b = a;
+            ";
+        var blockStatement = ParseStatement<BlockStatement>(inputText);
+
+        blockStatement.OpenBraceToken.Text.Should().Be("{");
+        blockStatement.OpenBraceToken.Kind.Should().Be(SyntaxKind.OpenBraceToken);
+
+        blockStatement.InnerStatements.Should().SatisfyRespectively(
+            _0 => _0.As<ExpressionStatement>().Should().NotBeNull(),
+            _1 => _1.As<ExpressionStatement>().Should().NotBeNull(),
+            _2 => _2.As<ExpressionStatement>().Should().NotBeNull());
+
+        blockStatement.CloseBraceToken.Text.Should().Be("");
+        blockStatement.CloseBraceToken.Kind.Should().Be(SyntaxKind.CloseBraceToken);
+        blockStatement.CloseBraceToken.Missing.Should().BeTrue();
+        //blockStatement.GetDiagnostics().Should().NotBeEmpty();
+    }
+}

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionCallExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionCallExpressionTests.cs
@@ -72,4 +72,14 @@ public sealed partial class ParserTests
             argument.Expression.As<LiteralExpression>().Text.Should().Be("\"123\"");
         });
     }
+
+    [Fact]
+    public void TestParseFunctionCallExpressionWithoutClosingBracket()
+    {
+        var inputText = "System.Int32.Parse(s: \"123\"";
+        var functionCallExpression = ParseExpression<FunctionCallExpression>(inputText);
+
+        functionCallExpression.Arguments.CloseParenthesisToken.Missing.Should().BeTrue();
+        //functionCallExpression.GetDiagnostics().Should().NotBeEmpty();
+    }
 }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/ParserTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/ParserTests.cs
@@ -6,8 +6,6 @@ using Xunit;
 
 namespace Todl.Compiler.Tests.CodeAnalysis
 {
-    using ArgumentsList = CommaSeparatedSyntaxList<Argument>;
-
     public sealed partial class ParserTests
     {
         private static TExpression ParseExpression<TExpression>(string sourceText)
@@ -77,30 +75,6 @@ namespace Todl.Compiler.Tests.CodeAnalysis
 
             var memberName = inputText[(inputText.LastIndexOf('.') + 1)..^0];
             memberAccessExpression.MemberIdentifierToken.Text.Should().Be(memberName);
-        }
-
-        [Fact]
-        public void TestParseBlockStatementBasic()
-        {
-            var inputText = @"
-            {
-                a = 1 + 2;
-                ++a;
-                b = a;
-            }
-            ";
-            var blockStatement = ParseStatement<BlockStatement>(inputText);
-
-            blockStatement.OpenBraceToken.Text.Should().Be("{");
-            blockStatement.OpenBraceToken.Kind.Should().Be(SyntaxKind.OpenBraceToken);
-
-            blockStatement.InnerStatements.Should().SatisfyRespectively(
-                _0 => _0.As<ExpressionStatement>().Should().NotBeNull(),
-                _1 => _1.As<ExpressionStatement>().Should().NotBeNull(),
-                _2 => _2.As<ExpressionStatement>().Should().NotBeNull());
-
-            blockStatement.CloseBraceToken.Text.Should().Be("}");
-            blockStatement.CloseBraceToken.Kind.Should().Be(SyntaxKind.CloseBraceToken);
         }
 
         [Fact]

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/BlockStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/BlockStatement.cs
@@ -17,15 +17,13 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
     {
         private BlockStatement ParseBlockStatement()
         {
-            var openBraceToken = this.ExpectToken(SyntaxKind.OpenBraceToken);
+            var openBraceToken = ExpectToken(SyntaxKind.OpenBraceToken);
             var innerStatements = new List<Statement>();
 
-            while (Current.Kind != SyntaxKind.CloseBraceToken)
+            var closeBraceToken = ExpectUntil(SyntaxKind.CloseBraceToken, () =>
             {
                 innerStatements.Add(ParseStatement());
-            }
-
-            var closeBraceToken = this.ExpectToken(SyntaxKind.CloseBraceToken);
+            });
 
             return new BlockStatement()
             {

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/CommaSeparatedSyntaxList.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/CommaSeparatedSyntaxList.cs
@@ -20,7 +20,7 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
             var openParenthesisToken = ExpectToken(SyntaxKind.OpenParenthesisToken);
             var items = new List<T>();
 
-            while (Current.Kind != SyntaxKind.CloseParenthesisToken)
+            var closeParenthesisToken = ExpectUntil(SyntaxKind.CloseParenthesisToken, () =>
             {
                 if (Current.Kind == SyntaxKind.CommaToken)
                 {
@@ -29,9 +29,7 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
 
                 var item = parseFunc();
                 items.Add(item);
-            }
-
-            var closeParenthesisToken = ExpectToken(SyntaxKind.CloseParenthesisToken);
+            });
 
             return new CommaSeparatedSyntaxList<T>()
             {

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
@@ -43,12 +43,24 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
 
         private SyntaxToken ExpectToken(SyntaxKind syntaxKind)
         {
-            if (this.Current.Kind == syntaxKind)
+            if (Current.Kind == syntaxKind)
             {
-                return this.NextToken();
+                return NextToken();
             }
 
             return ReportUnexpectedToken(syntaxKind);
+        }
+
+        private SyntaxToken ExpectUntil(SyntaxKind syntaxKind, Action action)
+        {
+            while (Current.Kind != syntaxKind
+                && Current.Kind != SyntaxKind.EndOfFileToken
+                && Current.Kind != SyntaxKind.BadToken)
+            {
+                action();
+            }
+
+            return ExpectToken(syntaxKind);
         }
 
         internal Parser(SyntaxTree syntaxTree)
@@ -63,7 +75,8 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
                 directives.Add(ParseDirective());
             }
 
-            while (Current.Kind != SyntaxKind.EndOfFileToken)
+            while (Current.Kind != SyntaxKind.EndOfFileToken
+                && Current.Kind != SyntaxKind.BadToken)
             {
                 members.Add(ParseMember());
             }


### PR DESCRIPTION
There are a couple of places in `Parser` that starts a while loop until it sees a specific token, e.g. 
```
while (Current.Kind != SyntaxKind.CloseBraceToken) { ParseSomething(); }
```
This will almost certainly lead to an infinite loop when the `CloseBraceToken` is missing in the input. Introducing `ExpectUntil` to guard against this issue by terminating the loop when seeing a `BadToken` or `EndOfFileToken`, in addition to the expected token.