### PR TITLE
[Engineering] Change BoundNodeFactorySourceGenerator to be IIncrementalSourceGenerator

### DIFF
--- a/src/Todl.Compiler.SourceGenerators/IndentedTextWriterExtensions.cs
+++ b/src/Todl.Compiler.SourceGenerators/IndentedTextWriterExtensions.cs
@@ -1,4 +1,4 @@
-using System.CodeDom.Compiler;
+﻿using System.CodeDom.Compiler;
 
 namespace Todl.Compiler.SourceGenerators;
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundNode.cs
@@ -14,6 +14,7 @@ public abstract class BoundNode : IDiagnosable
         if (DiagnosticBuilder == null)
         {
             return DiagnosticBag.Empty;
+
         }
 
         return DiagnosticBuilder.Build();


### PR DESCRIPTION
This PR modifies `BoundNodeFactorySourceGenerator` to implement `IIncrementalSourceGenerator` instead of the old `ISourceGenerator` interface. This is a performance improvement to the source generators because it allows the upstream toolset (e.g. code editors) to incrementally call the source generators.