### PR TITLE
[Bugfix] Fix null-ref in fibonacci sample

### DIFF
--- a/src/Todl.Compiler/CodeGeneration/Emitter.Expressions.cs
+++ b/src/Todl.Compiler/CodeGeneration/Emitter.Expressions.cs
@@ -153,7 +153,15 @@ internal partial class Emitter
 
             if (!boundClrFunctionCallExpression.IsStatic)
             {
-                EmitExpression(boundClrFunctionCallExpression.BoundBaseExpression);
+                if (boundClrFunctionCallExpression.BoundBaseExpression is BoundVariableExpression boundVariableExpression
+                    && boundVariableExpression.Variable is LocalVariableSymbol localVariableSymbol)
+                {
+                    EmitLocalAddress(localVariableSymbol);
+                }
+                else
+                {
+                    EmitExpression(boundClrFunctionCallExpression.BoundBaseExpression);
+                }
             }
 
             var methodReference = ResolveMethodReference(boundClrFunctionCallExpression);
@@ -248,7 +256,7 @@ internal partial class Emitter
             var slot = variables[localVariableSymbol].Index;
             if (slot < 0xFF)
             {
-                ILProcessor.Emit(OpCodes.Ldloca_S, (sbyte)slot);
+                ILProcessor.Emit(OpCodes.Ldloca_S, (byte)slot);
             }
             else
             {


### PR DESCRIPTION
This PR provides a temporary fix to the `NullReferenceException` thrown in the fibonacci sample. `const a = 10; a.ToString();` should emit `ldloca_S` instead of `ldloc_S` when referencing the local variable `a`. A permanent fix requires refactoring the emitter code which will be done later.