### PR TITLE
Fixing side effects not triggered in binary expression

### DIFF
--- a/samples/Fibonacci.Loop/Fibonacci.Loop.tdl
+++ b/samples/Fibonacci.Loop/Fibonacci.Loop.tdl
@@ -13,8 +13,7 @@ int fibonacci(int i) {
     let a = 1;
     let b = 1;
 
-    while i > 2 {
-        --i
+    while i-- > 2 {
         const c = a + b;
         a = b;
         b = c;

--- a/samples/Fibonacci.Loop/Fibonacci.Loop.tdlproj
+++ b/samples/Fibonacci.Loop/Fibonacci.Loop.tdlproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Todl.Compiler.Tests/TestUtils.cs
+++ b/src/Todl.Compiler.Tests/TestUtils.cs
@@ -52,11 +52,11 @@ internal static class TestUtils
 
     internal static void EmitExpressionAndVerify(string input, params TestInstruction[] expectedInstructions)
     {
-        var boundExpression = BindExpression<BoundExpression>(input);
-        boundExpression.GetDiagnostics().Should().BeEmpty();
+        var boundExpressionStatement = BindStatement<BoundExpressionStatement>(input);
+        boundExpressionStatement.GetDiagnostics().Should().BeEmpty();
 
         var emitter = new TestEmitter();
-        emitter.EmitExpression(boundExpression);
+        emitter.EmitStatement(boundExpressionStatement);
         emitter.Emit();
 
         emitter.ILProcessor.Body.Instructions.ShouldHaveExactInstructionSequence(expectedInstructions);

--- a/src/Todl.Compiler/CodeGeneration/Emitter.Expressions.cs
+++ b/src/Todl.Compiler/CodeGeneration/Emitter.Expressions.cs
@@ -20,7 +20,7 @@ internal partial class Emitter
                 && m.GetParameters().Length == 2
                 && m.GetParameters()[0].ParameterType.Equals(typeof(string)));
 
-        public void EmitExpression(BoundExpression boundExpression, bool emitSideEffect = false)
+        public void EmitExpression(BoundExpression boundExpression)
         {
             switch (boundExpression)
             {
@@ -37,7 +37,7 @@ internal partial class Emitter
                     EmitTodlFunctionCallExpression(boundTodlFunctionCallExpression);
                     return;
                 case BoundUnaryExpression boundUnaryExpression:
-                    EmitUnaryExpression(boundUnaryExpression, emitSideEffect);
+                    EmitUnaryExpression(boundUnaryExpression, true);
                     return;
                 case BoundBinaryExpression boundBinaryExpression:
                     EmitBinaryExpression(boundBinaryExpression);
@@ -274,7 +274,7 @@ internal partial class Emitter
         {
             foreach (var argument in boundTodlFunctionCallExpression.BoundArguments.Values)
             {
-                EmitExpression(argument, true);
+                EmitExpression(argument);
             }
 
             var methodReference = ResolveMethodReference(boundTodlFunctionCallExpression);
@@ -418,7 +418,7 @@ internal partial class Emitter
             if (left is BoundMemberAccessExpression boundMemberAccessExpression
                 && !boundMemberAccessExpression.IsStatic)
             {
-                EmitExpression(boundMemberAccessExpression.BoundBaseExpression, true);
+                EmitExpression(boundMemberAccessExpression.BoundBaseExpression);
             }
 
             assignmentAction();
@@ -489,7 +489,7 @@ internal partial class Emitter
         {
             EmitStore(boundAssignmentExpression.Left, () =>
             {
-                EmitExpression(boundAssignmentExpression.Right, true);
+                EmitExpression(boundAssignmentExpression.Right);
 
                 switch (boundAssignmentExpression.Operator.BoundAssignmentOperatorKind)
                 {

--- a/src/Todl.Compiler/CodeGeneration/Emitter.Statements.cs
+++ b/src/Todl.Compiler/CodeGeneration/Emitter.Statements.cs
@@ -19,7 +19,7 @@ internal partial class Emitter
                     EmitReturnStatement(boundReturnStatement);
                     return;
                 case BoundExpressionStatement boundExpressionStatement:
-                    EmitExpression(boundExpressionStatement.Expression);
+                    EmitExpressionStatement(boundExpressionStatement);
                     return;
                 case BoundConditionalStatement boundConditionalStatement:
                     EmitConditionalStatement(boundConditionalStatement);
@@ -33,6 +33,18 @@ internal partial class Emitter
                 default:
                     return;
             }
+        }
+
+        private void EmitExpressionStatement(BoundExpressionStatement boundExpressionStatement)
+        {
+            // standalone a++ shouldn't trigger side effect
+            if (boundExpressionStatement.Expression is BoundUnaryExpression boundUnaryExpression)
+            {
+                EmitUnaryExpression(boundUnaryExpression, false);
+                return;
+            }
+
+            EmitExpression(boundExpressionStatement.Expression);
         }
 
         private void EmitBlockStatement(BoundBlockStatement boundBlockStatement)
@@ -84,7 +96,7 @@ internal partial class Emitter
 
             if (boundVariableDeclarationStatement.InitializerExpression is not null)
             {
-                EmitExpression(boundVariableDeclarationStatement.InitializerExpression, true);
+                EmitExpression(boundVariableDeclarationStatement.InitializerExpression);
                 EmitLocalStore(variableDefinition);
             }
         }


### PR DESCRIPTION
This PR fixes an issue where side effects in a `BoundUnaryExpression` is not triggered when inside a `BoundBinaryExpression`. Here's an example of the issue

```
let i = 20;
while i-- > 0 {
  // do something
}
```
