### PR TITLE
Introducing BoundTreeVisitor and BoundTreeWalker

### DIFF
--- a/src/Todl.Compiler.SourceGenerators/BoundTreeVisitorSourceGenerator.cs
+++ b/src/Todl.Compiler.SourceGenerators/BoundTreeVisitorSourceGenerator.cs
@@ -30,9 +30,9 @@ internal sealed class BoundTreeVisitorSourceGenerator : IIncrementalGenerator
             namespace {{BoundTreeVisitorNamespace}};
 
             [System.CodeDom.Compiler.GeneratedCode("{{nameof(BoundTreeVisitorSourceGenerator)}}", "1.0.0.0")]
-            internal abstract partial class {{BoundTreeVisitorClassName}}<TArg, TRet>
+            internal abstract partial class {{BoundTreeVisitorClassName}}
             {
-                public virtual TRet DefaultVisit(BoundNode node, TArg arg) => default;
+                public virtual BoundNode DefaultVisit(BoundNode node) => default;
             }
             """, Encoding.UTF8);
 
@@ -48,9 +48,9 @@ internal sealed class BoundTreeVisitorSourceGenerator : IIncrementalGenerator
             var sourceText = SourceText.From($$"""
                 namespace {{BoundTreeVisitorNamespace}};
 
-                internal abstract partial class {{BoundTreeVisitorClassName}}<TArg, TRet>
+                internal abstract partial class {{BoundTreeVisitorClassName}}
                 {
-                    public virtual TRet Visit{{className}}({{className}} node, TArg arg) => DefaultVisit(node, arg);
+                    public virtual BoundNode Visit{{className}}({{className}} node) => DefaultVisit(node);
                 }
                 """, Encoding.UTF8);
 

--- a/src/Todl.Compiler.SourceGenerators/BoundTreeVisitorSourceGenerator.cs
+++ b/src/Todl.Compiler.SourceGenerators/BoundTreeVisitorSourceGenerator.cs
@@ -14,8 +14,6 @@ internal sealed class BoundTreeVisitorSourceGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterPostInitializationOutput(GenerateBoundTreeVisitorDefaultMethods);
-
         var pipeline = context.SyntaxProvider.ForAttributeWithMetadataName(
             fullyQualifiedMetadataName: $"{BoundTreeVisitorNamespace}.BoundNodeAttribute",
             predicate: static (syntaxNode, _) => syntaxNode is ClassDeclarationSyntax,
@@ -24,33 +22,20 @@ internal sealed class BoundTreeVisitorSourceGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(pipeline, GenerateBoundTreeVisitorMethods);
     }
 
-    static void GenerateBoundTreeVisitorDefaultMethods(IncrementalGeneratorPostInitializationContext context)
-    {
-        var sourceText = SourceText.From($$"""
-            namespace {{BoundTreeVisitorNamespace}};
-
-            [System.CodeDom.Compiler.GeneratedCode("{{nameof(BoundTreeVisitorSourceGenerator)}}", "1.0.0.0")]
-            internal abstract partial class {{BoundTreeVisitorClassName}}
-            {
-                public virtual BoundNode DefaultVisit(BoundNode node) => default;
-            }
-            """, Encoding.UTF8);
-
-        context.AddSource($"{BoundTreeVisitorClassName}.g.cs", sourceText);
-    }
-
     static void GenerateBoundTreeVisitorMethods(SourceProductionContext context, ISymbol symbol)
     {
         try
         {
             var className = symbol.Name;
+            var camelCaseClassName = symbol.CamelCasedName();
 
             var sourceText = SourceText.From($$"""
                 namespace {{BoundTreeVisitorNamespace}};
 
                 internal abstract partial class {{BoundTreeVisitorClassName}}
                 {
-                    public virtual BoundNode Visit{{className}}({{className}} node) => DefaultVisit(node);
+                    [System.CodeDom.Compiler.GeneratedCode("{{nameof(BoundTreeVisitorSourceGenerator)}}", "1.0.0.0")]
+                    public virtual BoundNode Visit{{className}}({{className}} {{camelCaseClassName}}) => DefaultVisit({{camelCaseClassName}});
                 }
                 """, Encoding.UTF8);
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundAssignmentExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundAssignmentExpressionTests.cs
@@ -18,7 +18,7 @@ public sealed class BoundAssignmentExpressionTests
     [InlineData("{ let n = 0; n -= 10; }", "n", BoundAssignmentOperatorKind.SubstractionInline, SpecialType.ClrInt32)]
     [InlineData("{ let n = 0; n *= 10; }", "n", BoundAssignmentOperatorKind.MultiplicationInline, SpecialType.ClrInt32)]
     [InlineData("{ let n = 0; n /= 10; }", "n", BoundAssignmentOperatorKind.DivisionInline, SpecialType.ClrInt32)]
-    public void TestBindAssignmentExpressionBasic(
+    void TestBindAssignmentExpressionBasic(
         string input,
         string variableName,
         BoundAssignmentOperatorKind expectedBoundAssignmentOperatorKind,

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundNodeTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundNodeTests.cs
@@ -19,7 +19,7 @@ public sealed class BoundNodeTests
 {
     [Theory]
     [MemberData(nameof(GetAllSyntaxNodesForTest))]
-    public void BoundNodeShouldHaveCorrectSyntaxNode(SyntaxNode syntaxNode, BoundNode boundNode)
+    void BoundNodeShouldHaveCorrectSyntaxNode(SyntaxNode syntaxNode, BoundNode boundNode)
     {
         boundNode.SyntaxNode.Should().NotBeNull();
         boundNode.SyntaxNode.Should().Be(syntaxNode);
@@ -28,7 +28,7 @@ public sealed class BoundNodeTests
     [Theory]
     [MemberData(nameof(GetAllSyntaxNodesForTest))]
     [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
-    public void DiagnosticBagShouldNotBeNull(SyntaxNode unused, BoundNode boundNode)
+    void DiagnosticBagShouldNotBeNull(SyntaxNode unused, BoundNode boundNode)
     {
         boundNode.DiagnosticBuilder.Should().NotBeNull();
         boundNode.GetDiagnostics().Should().NotBeNull();

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
@@ -21,9 +21,11 @@ internal sealed class BoundModule : IDiagnosable
         var binder = Binder.CreateModuleBinder(clrTypeCache);
         var entryPointType = binder.BindEntryPointTypeDefinition(syntaxTrees);
 
+        var controlFlowAnalyzer = new ControlFlowAnalyzer();
+        entryPointType.Accept(controlFlowAnalyzer);
+
         var boundNodeVisitors = new BoundNodeVisitor[]
         {
-            new ControlFlowAnalyzer(),
             new ConstantFoldingBoundNodeVisitor(binder.ConstantValueFactory)
         };
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
@@ -7,7 +7,7 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding;
 
-public sealed class BoundModule : IDiagnosable
+internal sealed class BoundModule : IDiagnosable
 {
     public IReadOnlyCollection<SyntaxTree> SyntaxTrees { get; private init; }
     public BoundEntryPointTypeDefinition EntryPointType { get; private init; }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundAssignmentExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundAssignmentExpression.cs
@@ -6,7 +6,7 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundAssignmentExpression : BoundExpression
+internal sealed class BoundAssignmentExpression : BoundExpression
 {
     public sealed class BoundAssignmentOperator
     {
@@ -45,6 +45,8 @@ public sealed class BoundAssignmentExpression : BoundExpression
     public BoundAssignmentOperator Operator { get; internal init; }
     public BoundExpression Right { get; internal init; }
     public override TypeSymbol ResultType => Right.ResultType;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundAssignmentExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBinaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBinaryExpression.cs
@@ -9,7 +9,7 @@ namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 using BinaryOperatorIndex = ValueTuple<TypeSymbol, TypeSymbol, SyntaxKind>;
 
 [BoundNode]
-public sealed class BoundBinaryExpression : BoundExpression
+internal sealed class BoundBinaryExpression : BoundExpression
 {
     public BoundBinaryOperator Operator { get; internal init; }
     public BoundExpression Left { get; internal init; }
@@ -17,6 +17,8 @@ public sealed class BoundBinaryExpression : BoundExpression
 
     public override TypeSymbol ResultType => Operator.ResultType;
     public override bool Constant => Left.Constant && Right.Constant;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundBinaryExpression(this);
 }
 
 public sealed record BoundBinaryOperator(

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBlockStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBlockStatement.cs
@@ -5,10 +5,12 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundBlockStatement : BoundStatement
+internal sealed class BoundBlockStatement : BoundStatement
 {
     public BoundScope Scope { get; internal init; }
     public IReadOnlyList<BoundStatement> Statements { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundBlockStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBreakStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBreakStatement.cs
@@ -4,9 +4,11 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundBreakStatement : BoundStatement
+internal sealed class BoundBreakStatement : BoundStatement
 {
     public BoundLoopContext BoundLoopContext { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundBreakStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
@@ -10,13 +10,15 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundClrFunctionCallExpression : BoundExpression
+internal sealed class BoundClrFunctionCallExpression : BoundExpression
 {
     public BoundExpression BoundBaseExpression { get; internal init; }
     public MethodInfo MethodInfo { get; internal init; }
     public IReadOnlyList<BoundExpression> BoundArguments { get; internal init; }
     public override TypeSymbol ResultType => BoundBaseExpression.SyntaxNode.SyntaxTree.ClrTypeCache.Resolve(MethodInfo.ReturnType);
     public bool IsStatic => MethodInfo.IsStatic;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundClrFunctionCallExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConditionalStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConditionalStatement.cs
@@ -7,7 +7,7 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundConditionalStatement : BoundStatement
+internal sealed class BoundConditionalStatement : BoundStatement
 {
     public BoundExpression Condition { get; internal init; }
     public BoundStatement Consequence { get; internal init; }
@@ -35,6 +35,8 @@ public sealed class BoundConditionalStatement : BoundStatement
 
         return this;
     }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundConditionalStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConstant.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConstant.cs
@@ -7,13 +7,15 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundConstant : BoundExpression
+internal sealed class BoundConstant : BoundExpression
 {
     public ConstantValue Value { get; internal init; }
 
     public override TypeSymbol ResultType => Value.ResultType;
 
     public override bool Constant => true;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundConstant(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundContinueStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundContinueStatement.cs
@@ -4,9 +4,11 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundContinueStatement : BoundStatement
+internal sealed class BoundContinueStatement : BoundStatement
 {
     public BoundLoopContext BoundLoopContext { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundContinueStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
@@ -6,7 +6,8 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public sealed class BoundEntryPointTypeDefinition : BoundTodlTypeDefinition
+[BoundNode]
+internal sealed class BoundEntryPointTypeDefinition : BoundTodlTypeDefinition
 {
     public const string EntryPointFunctionName = "Main";
     public const string GeneratedTypeName = "_Todl_Generated_EntryPoint_";
@@ -53,11 +54,13 @@ public sealed class BoundEntryPointTypeDefinition : BoundTodlTypeDefinition
 
         return true;
     }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundEntryPointTypeDefinition(this);
 }
 
 public partial class Binder
 {
-    public BoundEntryPointTypeDefinition BindEntryPointTypeDefinition(IEnumerable<SyntaxTree> syntaxTrees)
+    internal BoundEntryPointTypeDefinition BindEntryPointTypeDefinition(IEnumerable<SyntaxTree> syntaxTrees)
     {
         var typeBinder = CreateTypeBinder();
         var diagnosticBuilder = new DiagnosticBag.Builder();

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundExpression.cs
@@ -4,7 +4,7 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public abstract class BoundExpression : BoundNode
+internal abstract class BoundExpression : BoundNode
 {
     public virtual TypeSymbol ResultType { get; }
     public virtual bool LValue => false;

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundExpressionStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundExpressionStatement.cs
@@ -1,18 +1,19 @@
 ﻿using Todl.Compiler.CodeAnalysis.Syntax;
 
-namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree
-{
-    [BoundNode]
-    public sealed class BoundExpressionStatement : BoundStatement
-    {
-        public BoundExpression Expression { get; internal init; }
-    }
+namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-    public partial class Binder
-    {
-        private BoundExpressionStatement BindExpressionStatement(ExpressionStatement expressionStatement)
-            => BoundNodeFactory.CreateBoundExpressionStatement(
-                syntaxNode: expressionStatement,
-                expression: BindExpression(expressionStatement.Expression));
-    }
+[BoundNode]
+internal sealed class BoundExpressionStatement : BoundStatement
+{
+    public BoundExpression Expression { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundExpressionStatement(this);
+}
+
+public partial class Binder
+{
+    private BoundExpressionStatement BindExpressionStatement(ExpressionStatement expressionStatement)
+        => BoundNodeFactory.CreateBoundExpressionStatement(
+            syntaxNode: expressionStatement,
+            expression: BindExpression(expressionStatement.Expression));
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
@@ -3,71 +3,72 @@ using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.Diagnostics;
 
-namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree
+namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
+
+[BoundNode]
+internal sealed class BoundFunctionMember : BoundMember
 {
-    [BoundNode]
-    public sealed class BoundFunctionMember : BoundMember
-    {
-        public BoundScope FunctionScope { get; internal init; }
-        public BoundBlockStatement Body { get; internal init; }
-        public FunctionSymbol FunctionSymbol { get; internal init; }
+    public BoundScope FunctionScope { get; internal init; }
+    public BoundBlockStatement Body { get; internal init; }
+    public FunctionSymbol FunctionSymbol { get; internal init; }
 
-        public TypeSymbol ReturnType => FunctionSymbol.ReturnType;
-        public bool IsPublic => FunctionSymbol.IsPublic;
-    }
+    public TypeSymbol ReturnType => FunctionSymbol.ReturnType;
+    public bool IsPublic => FunctionSymbol.IsPublic;
 
-    public partial class Binder
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundFunctionMember(this);
+}
+
+public partial class Binder
+{
+    private BoundFunctionMember BindFunctionDeclarationMember(FunctionDeclarationMember functionDeclarationMember)
     {
-        private BoundFunctionMember BindFunctionDeclarationMember(FunctionDeclarationMember functionDeclarationMember)
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var functionSymbol = Scope.LookupFunctionSymbol(functionDeclarationMember);
+        var functionBinder = CreateFunctionBinder(functionSymbol);
+
+        var duplicate = functionSymbol
+            .Parameters
+            .GroupBy(p => p.Name)
+            .FirstOrDefault(g => g.Count() > 1);
+
+        if (duplicate is not null)
         {
-            var diagnosticBuilder = new DiagnosticBag.Builder();
-            var functionSymbol = Scope.LookupFunctionSymbol(functionDeclarationMember);
-            var functionBinder = CreateFunctionBinder(functionSymbol);
-
-            var duplicate = functionSymbol
-                .Parameters
-                .GroupBy(p => p.Name)
-                .FirstOrDefault(g => g.Count() > 1);
-
-            if (duplicate is not null)
+            diagnosticBuilder.Add(new Diagnostic()
             {
-                diagnosticBuilder.Add(new Diagnostic()
-                {
-                    Message = $"Parameter '{duplicate.First().Name}' is a duplicate",
-                    ErrorCode = ErrorCode.DuplicateParameterName,
-                    Level = DiagnosticLevel.Error,
-                    TextLocation = functionDeclarationMember.Name.GetTextLocation()
-                });
-            }
-
-            foreach (var parameter in functionSymbol.Parameters)
-            {
-                functionBinder.Scope.DeclareVariable(parameter);
-            }
-
-            var body = functionBinder.BindBlockStatementInScope(functionDeclarationMember.Body);
-            if (functionSymbol.ReturnType.SpecialType == SpecialType.ClrVoid)
-            {
-                if (!body.Statements.Any() || body.Statements[^1] is not BoundReturnStatement)
-                {
-                    var returnStatement = BoundNodeFactory.CreateBoundReturnStatement(
-                        syntaxNode: null,
-                        boundReturnValueExpression: null,
-                        diagnosticBuilder: diagnosticBuilder);
-
-                    body = BoundNodeFactory.CreateBoundBlockStatement(
-                        syntaxNode: body.SyntaxNode,
-                        scope: body.Scope,
-                        statements: body.Statements.Append(returnStatement).ToList());
-                }
-            }
-
-            return BoundNodeFactory.CreateBoundFunctionMember(
-                syntaxNode: functionDeclarationMember,
-                functionScope: functionBinder.Scope,
-                body: body,
-                functionSymbol: functionSymbol,
-                diagnosticBuilder: diagnosticBuilder);
+                Message = $"Parameter '{duplicate.First().Name}' is a duplicate",
+                ErrorCode = ErrorCode.DuplicateParameterName,
+                Level = DiagnosticLevel.Error,
+                TextLocation = functionDeclarationMember.Name.GetTextLocation()
+            });
         }
+
+        foreach (var parameter in functionSymbol.Parameters)
+        {
+            functionBinder.Scope.DeclareVariable(parameter);
+        }
+
+        var body = functionBinder.BindBlockStatementInScope(functionDeclarationMember.Body);
+        if (functionSymbol.ReturnType.SpecialType == SpecialType.ClrVoid)
+        {
+            if (!body.Statements.Any() || body.Statements[^1] is not BoundReturnStatement)
+            {
+                var returnStatement = BoundNodeFactory.CreateBoundReturnStatement(
+                    syntaxNode: null,
+                    boundReturnValueExpression: null,
+                    diagnosticBuilder: diagnosticBuilder);
+
+                body = BoundNodeFactory.CreateBoundBlockStatement(
+                    syntaxNode: body.SyntaxNode,
+                    scope: body.Scope,
+                    statements: body.Statements.Append(returnStatement).ToList());
+            }
+        }
+
+        return BoundNodeFactory.CreateBoundFunctionMember(
+            syntaxNode: functionDeclarationMember,
+            functionScope: functionBinder.Scope,
+            body: body,
+            functionSymbol: functionSymbol,
+            diagnosticBuilder: diagnosticBuilder);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
@@ -4,12 +4,14 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundLoopStatement : BoundStatement
+internal sealed class BoundLoopStatement : BoundStatement
 {
     public BoundExpression Condition { get; internal init; }
     public bool ConditionNegated { get; internal init; }
     public BoundStatement Body { get; internal init; }
     public BoundLoopContext BoundLoopContext { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundLoopStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMember.cs
@@ -3,11 +3,11 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public abstract class BoundMember : BoundNode { }
+internal abstract class BoundMember : BoundNode { }
 
 public partial class Binder
 {
-    public BoundMember BindMember(Member member)
+    internal BoundMember BindMember(Member member)
         => member switch
         {
             FunctionDeclarationMember functionDeclarationMember => BindFunctionDeclarationMember(functionDeclarationMember),

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
@@ -7,7 +7,7 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public abstract class BoundMemberAccessExpression : BoundExpression
+internal abstract class BoundMemberAccessExpression : BoundExpression
 {
     public abstract BoundExpression BoundBaseExpression { get; internal init; }
     public abstract string MemberName { get; }
@@ -18,7 +18,7 @@ public abstract class BoundMemberAccessExpression : BoundExpression
 }
 
 [BoundNode]
-public sealed class BoundClrFieldAccessExpression : BoundMemberAccessExpression
+internal sealed class BoundClrFieldAccessExpression : BoundMemberAccessExpression
 {
     public override BoundExpression BoundBaseExpression { get; internal init; }
     public FieldInfo FieldInfo { get; internal init; }
@@ -31,10 +31,12 @@ public sealed class BoundClrFieldAccessExpression : BoundMemberAccessExpression
     public override bool Constant => FieldInfo.IsLiteral;
     public override bool ReadOnly => Constant || FieldInfo.IsInitOnly;
     public override bool IsPublic => FieldInfo.IsPublic;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundClrFieldAccessExpression(this);
 }
 
 [BoundNode]
-public sealed class BoundClrPropertyAccessExpression : BoundMemberAccessExpression
+internal sealed class BoundClrPropertyAccessExpression : BoundMemberAccessExpression
 {
     public override BoundExpression BoundBaseExpression { get; internal init; }
     public PropertyInfo PropertyInfo { get; internal init; }
@@ -49,17 +51,21 @@ public sealed class BoundClrPropertyAccessExpression : BoundMemberAccessExpressi
 
     public MethodInfo GetMethod => PropertyInfo.GetMethod;
     public MethodInfo SetMethod => PropertyInfo.SetMethod;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundClrPropertyAccessExpression(this);
 }
 
 // This is not emittable, just to place a node in the bound tree to indicate this is an error
 [BoundNode]
-public sealed class BoundInvalidMemberAccessExpression : BoundMemberAccessExpression
+internal sealed class BoundInvalidMemberAccessExpression : BoundMemberAccessExpression
 {
     public override BoundExpression BoundBaseExpression { get; internal init; }
 
     public override string MemberName => string.Empty;
     public override bool IsStatic => false;
     public override bool IsPublic => true;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundInvalidMemberAccessExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNoOpStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNoOpStatement.cs
@@ -1,4 +1,7 @@
 ﻿namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundNoOpStatement : BoundStatement { }
+internal sealed class BoundNoOpStatement : BoundStatement
+{
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundNoOpStatement(this);
+}

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNode.cs
@@ -4,10 +4,12 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public abstract class BoundNode : IDiagnosable
+internal abstract class BoundNode : IDiagnosable
 {
     public SyntaxNode SyntaxNode { get; internal init; }
     public DiagnosticBag.Builder DiagnosticBuilder { get; internal init; }
+
+    public abstract BoundNode Accept(BoundTreeVisitor visitor);
 
     public virtual IEnumerable<Diagnostic> GetDiagnostics()
     {

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
@@ -10,12 +10,14 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundObjectCreationExpression : BoundExpression
+internal sealed class BoundObjectCreationExpression : BoundExpression
 {
     public ConstructorInfo ConstructorInfo { get; internal init; }
     public IReadOnlyList<BoundExpression> BoundArguments { get; internal init; }
     public override TypeSymbol ResultType
         => SyntaxNode.SyntaxTree.ClrTypeCache.Resolve(ConstructorInfo.DeclaringType);
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundObjectCreationExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundReturnStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundReturnStatement.cs
@@ -5,13 +5,15 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundReturnStatement : BoundStatement
+internal sealed class BoundReturnStatement : BoundStatement
 {
     public BoundExpression BoundReturnValueExpression { get; internal init; }
 
     public TypeSymbol ReturnType
         => BoundReturnValueExpression?.ResultType
         ?? SyntaxNode.SyntaxTree.ClrTypeCache.BuiltInTypes.Void;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundReturnStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundStatement.cs
@@ -3,11 +3,11 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public abstract class BoundStatement : BoundNode { }
+internal abstract class BoundStatement : BoundNode { }
 
 public partial class Binder
 {
-    public BoundStatement BindStatement(Statement statement)
+    internal BoundStatement BindStatement(Statement statement)
         => statement switch
         {
             ExpressionStatement expressionStatement => BindExpressionStatement(expressionStatement),

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlFunctionCallExpression.cs
@@ -7,13 +7,15 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundTodlFunctionCallExpression : BoundExpression
+internal sealed class BoundTodlFunctionCallExpression : BoundExpression
 {
     public FunctionSymbol FunctionSymbol { get; internal set; }
     public IReadOnlyDictionary<string, BoundExpression> BoundArguments { get; internal init; }
 
     public override TypeSymbol ResultType
         => FunctionSymbol?.ReturnType ?? default; // TODO: we may need something like TypeSymbol.InvalidType for this
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundTodlFunctionCallExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlTypeDefinition.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlTypeDefinition.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-public abstract class BoundTodlTypeDefinition : BoundNode
+internal abstract class BoundTodlTypeDefinition : BoundNode
 {
     public string Name { get; internal init; }
     public IReadOnlyList<BoundMember> BoundMembers { get; internal init; }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeVisitor.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeVisitor.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+
+namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
+
+internal abstract partial class BoundTreeVisitor
+{
+    [DebuggerHidden]
+    public virtual BoundNode DefaultVisit(BoundNode node) => default;
+
+    [DebuggerHidden]
+    public virtual BoundNode Visit(BoundNode node) => node?.Accept(this);
+}

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeWalker.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeWalker.cs
@@ -1,0 +1,172 @@
+﻿using System.Collections.Generic;
+
+namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
+
+/// <summary>
+/// BoundTreeWalker walks and observes the BoundTree without altering the nodes
+/// </summary>
+internal abstract class BoundTreeWalker : BoundTreeVisitor
+{
+    public override BoundNode VisitBoundAssignmentExpression(BoundAssignmentExpression boundAssignmentExpression)
+    {
+        Visit(boundAssignmentExpression.Left);
+        Visit(boundAssignmentExpression.Right);
+
+        return boundAssignmentExpression;
+    }
+
+    public override BoundNode VisitBoundBinaryExpression(BoundBinaryExpression boundBinaryExpression)
+    {
+        Visit(boundBinaryExpression.Left);
+        Visit(boundBinaryExpression.Right);
+
+        return boundBinaryExpression;
+    }
+
+    public override BoundNode VisitBoundBlockStatement(BoundBlockStatement boundBlockStatement)
+    {
+        VisitList(boundBlockStatement.Statements);
+
+        return boundBlockStatement;
+    }
+
+    public override BoundNode VisitBoundBreakStatement(BoundBreakStatement boundBreakStatement)
+        => boundBreakStatement;
+
+    public override BoundNode VisitBoundClrFieldAccessExpression(BoundClrFieldAccessExpression boundClrFieldAccessExpression)
+    {
+        Visit(boundClrFieldAccessExpression.BoundBaseExpression);
+
+        return boundClrFieldAccessExpression;
+    }
+
+    public override BoundNode VisitBoundClrFunctionCallExpression(BoundClrFunctionCallExpression boundClrFunctionCallExpression)
+    {
+        Visit(boundClrFunctionCallExpression.BoundBaseExpression);
+        VisitList(boundClrFunctionCallExpression.BoundArguments);
+
+        return boundClrFunctionCallExpression;
+    }
+
+    public override BoundNode VisitBoundClrPropertyAccessExpression(BoundClrPropertyAccessExpression boundClrPropertyAccessExpression)
+    {
+        Visit(boundClrPropertyAccessExpression.BoundBaseExpression);
+
+        return boundClrPropertyAccessExpression;
+    }
+
+    public override BoundNode VisitBoundConditionalStatement(BoundConditionalStatement boundConditionalStatement)
+    {
+        Visit(boundConditionalStatement.Condition);
+        Visit(boundConditionalStatement.Consequence);
+        Visit(boundConditionalStatement.Alternative);
+
+        return boundConditionalStatement;
+    }
+
+    public override BoundNode VisitBoundConstant(BoundConstant boundConstant)
+        => boundConstant;
+
+    public override BoundNode VisitBoundContinueStatement(BoundContinueStatement boundContinueStatement)
+        => boundContinueStatement;
+
+    public override BoundNode VisitBoundEntryPointTypeDefinition(BoundEntryPointTypeDefinition boundEntryPointTypeDefinition)
+    {
+        VisitList(boundEntryPointTypeDefinition.BoundMembers);
+
+        return boundEntryPointTypeDefinition;
+    }
+
+    public override BoundNode VisitBoundExpressionStatement(BoundExpressionStatement boundExpressionStatement)
+    {
+        Visit(boundExpressionStatement.Expression);
+
+        return boundExpressionStatement;
+    }
+
+    public override BoundNode VisitBoundFunctionMember(BoundFunctionMember boundFunctionMember)
+    {
+        Visit(boundFunctionMember.Body);
+
+        return boundFunctionMember;
+    }
+
+    public override BoundNode VisitBoundInvalidMemberAccessExpression(BoundInvalidMemberAccessExpression boundInvalidMemberAccess)
+    {
+        Visit(boundInvalidMemberAccess.BoundBaseExpression);
+
+        return boundInvalidMemberAccess;
+    }
+
+    public override BoundNode VisitBoundLoopStatement(BoundLoopStatement boundLoopStatement)
+    {
+        Visit(boundLoopStatement.Condition);
+        Visit(boundLoopStatement.Body);
+
+        return boundLoopStatement;
+    }
+
+    public override BoundNode VisitBoundNoOpStatement(BoundNoOpStatement boundNoOpStatement)
+        => boundNoOpStatement;
+
+    public override BoundNode VisitBoundObjectCreationExpression(BoundObjectCreationExpression boundObjectCreationExpression)
+    {
+        VisitList(boundObjectCreationExpression.BoundArguments);
+
+        return boundObjectCreationExpression;
+    }
+
+    public override BoundNode VisitBoundReturnStatement(BoundReturnStatement boundReturnStatement)
+    {
+        Visit(boundReturnStatement.BoundReturnValueExpression);
+
+        return boundReturnStatement;
+    }
+
+    public override BoundNode VisitBoundTodlFunctionCallExpression(BoundTodlFunctionCallExpression boundTodlFunctionCallExpression)
+    {
+        VisitList(boundTodlFunctionCallExpression.BoundArguments.Values);
+
+        return boundTodlFunctionCallExpression;
+    }
+
+    public override BoundNode VisitBoundTypeExpression(BoundTypeExpression boundTypeExpression)
+        => boundTypeExpression;
+
+    public override BoundNode VisitBoundUnaryExpression(BoundUnaryExpression boundUnaryExpression)
+    {
+        Visit(boundUnaryExpression.Operand);
+
+        return boundUnaryExpression;
+    }
+
+    public override BoundNode VisitBoundVariableDeclarationStatement(BoundVariableDeclarationStatement boundVariableDeclarationStatement)
+    {
+        Visit(boundVariableDeclarationStatement.InitializerExpression);
+
+        return boundVariableDeclarationStatement;
+    }
+
+    public override BoundNode VisitBoundVariableExpression(BoundVariableExpression boundVariableExpression)
+        => boundVariableExpression;
+
+    public override BoundNode VisitBoundVariableMember(BoundVariableMember boundVariableMember)
+    {
+        Visit(boundVariableMember.BoundVariableDeclarationStatement);
+
+        return boundVariableMember;
+    }
+
+    private void VisitList<TBoundNode>(IEnumerable<TBoundNode> list) where TBoundNode : BoundNode
+    {
+        if (list is null)
+        {
+            return;
+        }
+
+        foreach (var node in list)
+        {
+            Visit(node);
+        }
+    }
+}

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTypeExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTypeExpression.cs
@@ -5,11 +5,13 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundTypeExpression : BoundExpression
+internal sealed class BoundTypeExpression : BoundExpression
 {
     internal TypeSymbol TargetType { get; init; }
 
     public override TypeSymbol ResultType => TargetType;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundTypeExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundUnaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundUnaryExpression.cs
@@ -8,7 +8,7 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundUnaryExpression : BoundExpression
+internal sealed class BoundUnaryExpression : BoundExpression
 {
     public BoundUnaryOperator Operator { get; internal init; }
     public BoundExpression Operand { get; internal init; }
@@ -17,6 +17,8 @@ public sealed class BoundUnaryExpression : BoundExpression
         => Operand.SyntaxNode.SyntaxTree.ClrTypeCache.ResolveSpecialType(Operator.ResultType);
 
     public override bool Constant => Operand.Constant;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundUnaryExpression(this);
 }
 
 // Values are copied from https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorKind.cs

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableDeclarationStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableDeclarationStatement.cs
@@ -4,10 +4,12 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundVariableDeclarationStatement : BoundStatement
+internal sealed class BoundVariableDeclarationStatement : BoundStatement
 {
     public LocalVariableSymbol Variable { get; internal init; }
     public BoundExpression InitializerExpression { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundVariableDeclarationStatement(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableExpression.cs
@@ -5,13 +5,15 @@ using Todl.Compiler.Diagnostics;
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundVariableExpression : BoundExpression
+internal sealed class BoundVariableExpression : BoundExpression
 {
     public VariableSymbol Variable { get; internal init; }
     public override TypeSymbol ResultType => Variable.Type;
     public override bool LValue => true;
     public override bool Constant => Variable.Constant;
     public override bool ReadOnly => Variable.ReadOnly;
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundVariableExpression(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableMember.cs
@@ -3,9 +3,11 @@
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 [BoundNode]
-public sealed class BoundVariableMember : BoundMember
+internal sealed class BoundVariableMember : BoundMember
 {
     public BoundVariableDeclarationStatement BoundVariableDeclarationStatement { get; internal init; }
+
+    public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundVariableMember(this);
 }
 
 public partial class Binder

--- a/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowAnalyzer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowAnalyzer.cs
@@ -4,9 +4,9 @@ using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.ControlFlowAnalysis;
 
-internal class ControlFlowAnalyzer : BoundNodeVisitor
+internal sealed class ControlFlowAnalyzer : BoundTreeWalker
 {
-    protected override BoundMember VisitBoundFunctionMember(BoundFunctionMember boundFunctionMember)
+    public override BoundNode VisitBoundFunctionMember(BoundFunctionMember boundFunctionMember)
     {
         var controlFlowGraph = ControlFlowGraph.Create(boundFunctionMember);
 

--- a/src/Todl.Compiler/CodeAnalysis/Symbols/LocalVariableSymbol.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Symbols/LocalVariableSymbol.cs
@@ -4,7 +4,7 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 
 namespace Todl.Compiler.CodeAnalysis.Symbols;
 
-public sealed class LocalVariableSymbol : VariableSymbol
+internal sealed class LocalVariableSymbol : VariableSymbol
 {
     public VariableDeclarationStatement VariableDeclarationStatement { get; internal init; }
     public BoundExpression BoundInitializer { get; internal init; }

--- a/src/Todl.Compiler/CodeAnalysis/Symbols/ReplVariableSymbol.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Symbols/ReplVariableSymbol.cs
@@ -5,7 +5,7 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 namespace Todl.Compiler.CodeAnalysis.Symbols;
 
 // only used in repl to create on-the-fly variables
-public sealed class ReplVariableSymbol : VariableSymbol
+internal sealed class ReplVariableSymbol : VariableSymbol
 {
     public AssignmentExpression AssignmentExpression { get; internal init; }
     public BoundExpression BoundInitializer { get; internal init; }

--- a/src/Todl.Compiler/CodeGeneration/Compilation.cs
+++ b/src/Todl.Compiler/CodeGeneration/Compilation.cs
@@ -16,7 +16,7 @@ public sealed class Compilation : IDisposable, IDiagnosable
 {
     public string AssemblyName { get; }
     public Version Version { get; }
-    public BoundModule MainModule { get; }
+    internal BoundModule MainModule { get; }
     public ClrTypeCache ClrTypeCache { get; }
 
     private readonly MetadataLoadContext metadataLoadContext;

--- a/src/Todl.Playground/Handlers/CompileRequestMessageHandler.cs
+++ b/src/Todl.Playground/Handlers/CompileRequestMessageHandler.cs
@@ -40,7 +40,7 @@ public class CompileRequestMessageHandler
         });
 
         using var compilation = compilationProvider.Compile(sourceTexts);
-        var diagnostics = compilation.MainModule.GetDiagnostics();
+        var diagnostics = compilation.GetDiagnostics();
 
         if (diagnostics.HasError())
         {

--- a/src/Todl.Sdk/CoreTodlCompileTask.cs
+++ b/src/Todl.Sdk/CoreTodlCompileTask.cs
@@ -41,7 +41,7 @@ public sealed class CoreTodlCompileTask : Task
                 sourceTexts: SourceFiles.Select(SourceText.FromFile),
                 metadataLoadContext: metadataLoadContext);
 
-            var diagnostics = compilation.MainModule.GetDiagnostics();
+            var diagnostics = compilation.GetDiagnostics();
 
             foreach (var d in diagnostics)
             {


### PR DESCRIPTION
## Summary
This PR introduces `BoundTreeVisitor` and `BoundTreeWalker` patterns to all the bound nodes.
This PR also converted `ControlGraphAnalyzer` to inherit from `BoundTreeWalker`.

## Detail
Similar to roslyn, we use the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern) to traverse the `BoundTree` and the nodes. This requires that
* All sealed `BoundNode` types needs to implement `Accept(T)` method. (This could even be generated in the future)
* We have a corresponding virtual `Visit*` method present in the `BoundTreeVisitor` base class.

The benefit to this approach is that we don't need a centralized `Visit` method with `switch` statements for every single `BoundNode` types.

### BoundTreeVisitor
`BoundTreeVisitor` class is the base class which has all the `Visit*` methods return `null`. It provides boilerplate code for children classes to extend. Analyzers and rewriters should not directly inherit from this class and instead use `BoundTreeWalker` or `BoundTreeRewriter` (not implemented yet).

### BoundTreeWalker
`BoundTreeWalker` class inherits from `BoundTreeVisitor` and provides basic depth-first traversal functionality. All nodes are examined and are not modified. Analyzers that don't modify the nodes should inherit from this class.

### BoundTreeRewriter (not in this PR)
`BoundTreeRewriter` class also inherits from `BoundTreeVisitor`. It is similar to `BoundTreeWalker` but nodes can be updated (note, `BoundNode`s are immutable by design so here "updates" to the node actually creates a new node and replace the old one). The detailed implementation will be provided in future PRs.