### PR TITLE
Add initial support for single line comments

### DIFF
--- a/samples/fibonacci/fibonacci.tdl
+++ b/samples/fibonacci/fibonacci.tdl
@@ -14,5 +14,6 @@ int fibonacci(int i) {
         return 1;
     }
 
+    // recursively call fibonacci until it reaches 1 or 2
     return fibonacci(i - 1) + fibonacci(i - 2);
 }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
@@ -56,7 +56,8 @@ namespace Todl.Compiler.Tests.CodeAnalysis
                 SyntaxKind.NumberToken,
                 SyntaxKind.IdentifierToken,
                 SyntaxKind.WhitespaceTrivia,
-                SyntaxKind.LineBreakTrivia
+                SyntaxKind.LineBreakTrivia,
+                SyntaxKind.SingleLineCommentTrivia
             }.ToHashSet();
 
             var uncoveredKinds = Enum.GetValues<SyntaxKind>().Except(actualTokenKinds.Union(exemptions));

--- a/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
@@ -6,155 +6,196 @@ using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.CodeAnalysis.Text;
 using Xunit;
 
-namespace Todl.Compiler.Tests.CodeAnalysis
+namespace Todl.Compiler.Tests.CodeAnalysis;
+
+public sealed partial class LexerTests
 {
-    public sealed partial class LexerTests
+    private SyntaxToken LexSingle(string text)
     {
-        private SyntaxToken LexSingle(string text)
+        var tokens = Lex(text);
+        tokens.Count.Should().Be(2);
+        tokens[0].GetDiagnostics().Should().BeEmpty();
+
+        return tokens.First();
+    }
+
+    private IReadOnlyList<SyntaxToken> Lex(string text)
+    {
+        var lexer = new Lexer() { SourceText = SourceText.FromString(text) };
+        lexer.Lex();
+        lexer.SyntaxTokens[^1].Kind.Should().Be(SyntaxKind.EndOfFileToken);
+
+        return lexer.SyntaxTokens;
+    }
+
+    [Fact]
+    public void TestLexerBasics()
+    {
+        var sourceText = SourceText.FromString("1+    2 +3");
+        var lexer = new Lexer() { SourceText = sourceText };
+        lexer.Lex();
+
+        var tokens = lexer.SyntaxTokens;
+        tokens.Count.Should().Be(6); // '1', '+', '2', '+', '3' and EndOfFileToken
+        tokens.SelectMany(t => t.GetDiagnostics()).Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(GetTestSingleTokenData))]
+    public void TestSingleToken(SyntaxKind kind, string text)
+    {
+        var token = LexSingle(text);
+        token.Kind.Should().Be(kind);
+        token.Text.Should().Be(text);
+    }
+
+    [Fact]
+    public void SingleTokenTestDataShouldCoverAllTokenKinds()
+    {
+        var actualTokenKinds = singleTokenTestData.Keys.ToHashSet();
+        var exemptions = new SyntaxKind[]
         {
-            var lexer = new Lexer() { SourceText = SourceText.FromString(text) };
-            lexer.Lex();
+            SyntaxKind.BadToken,
+            SyntaxKind.EndOfFileToken,
+            SyntaxKind.StringToken,
+            SyntaxKind.NumberToken,
+            SyntaxKind.IdentifierToken,
+            SyntaxKind.WhitespaceTrivia,
+            SyntaxKind.LineBreakTrivia,
+            SyntaxKind.SingleLineCommentTrivia
+        }.ToHashSet();
 
-            var tokens = lexer.SyntaxTokens;
-            tokens.Count.Should().Be(2);
-            tokens.Last().Kind.Should().Be(SyntaxKind.EndOfFileToken);
-            lexer.SyntaxTokens[0].GetDiagnostics().Should().BeEmpty();
+        var uncoveredKinds = Enum.GetValues<SyntaxKind>().Except(actualTokenKinds.Union(exemptions));
+        uncoveredKinds.Should().BeEmpty();
+    }
 
-            return tokens.First();
-        }
+    public static IEnumerable<object[]> GetTestSingleTokenData()
+        => singleTokenTestData.Select(kv => new object[] { kv.Key, kv.Value });
 
-        [Fact]
-        public void TestLexerBasics()
-        {
-            var sourceText = SourceText.FromString("1+    2 +3");
-            var lexer = new Lexer() { SourceText = sourceText };
-            lexer.Lex();
+    private static readonly Dictionary<SyntaxKind, string> singleTokenTestData = new()
+    {
+        { SyntaxKind.PlusToken, "+" },
+        { SyntaxKind.PlusPlusToken, "++" },
+        { SyntaxKind.PlusEqualsToken, "+=" },
+        { SyntaxKind.MinusToken, "-" },
+        { SyntaxKind.MinusMinusToken, "--" },
+        { SyntaxKind.MinusEqualsToken, "-=" },
+        { SyntaxKind.StarToken, "*" },
+        { SyntaxKind.StarEqualsToken, "*=" },
+        { SyntaxKind.SlashToken, "/" },
+        { SyntaxKind.SlashEqualsToken, "/=" },
+        { SyntaxKind.OpenParenthesisToken, "(" },
+        { SyntaxKind.CloseParenthesisToken, ")" },
+        { SyntaxKind.EqualsToken, "=" },
+        { SyntaxKind.EqualsEqualsToken, "==" },
+        { SyntaxKind.BangToken, "!" },
+        { SyntaxKind.BangEqualsToken, "!=" },
+        { SyntaxKind.LessThanToken, "<" },
+        { SyntaxKind.LessThanOrEqualsToken, "<=" },
+        { SyntaxKind.GreaterThanToken, ">" },
+        { SyntaxKind.GreaterThanOrEqualsToken, ">=" },
+        { SyntaxKind.AmpersandToken, "&" },
+        { SyntaxKind.AmpersandAmpersandToken, "&&" },
+        { SyntaxKind.PipeToken, "|" },
+        { SyntaxKind.PipePipeToken, "||" },
+        { SyntaxKind.TildeToken, "~" },
+        { SyntaxKind.DotToken, "." },
+        { SyntaxKind.CommaToken, "," },
+        { SyntaxKind.TrueKeywordToken, "true" },
+        { SyntaxKind.FalseKeywordToken, "false" },
+        { SyntaxKind.OpenBraceToken, "{" },
+        { SyntaxKind.CloseBraceToken, "}" },
+        { SyntaxKind.OpenBracketToken, "[" },
+        { SyntaxKind.CloseBracketToken, "]" },
+        { SyntaxKind.SemicolonToken, ";" },
+        { SyntaxKind.ColonToken, ":" },
+        { SyntaxKind.LetKeywordToken, "let" },
+        { SyntaxKind.ConstKeywordToken, "const" },
+        { SyntaxKind.ImportKeywordToken, "import" },
+        { SyntaxKind.FromKeywordToken, "from" },
+        { SyntaxKind.NewKeywordToken, "new" },
+        { SyntaxKind.BoolKeywordToken, "bool" },
+        { SyntaxKind.ByteKeywordToken, "byte" },
+        { SyntaxKind.CharKeywordToken, "char" },
+        { SyntaxKind.IntKeywordToken, "int" },
+        { SyntaxKind.LongKeywordToken, "long" },
+        { SyntaxKind.StringKeywordToken, "string" },
+        { SyntaxKind.VoidKeywordToken, "void" },
+        { SyntaxKind.ReturnKeywordToken, "return" },
+        { SyntaxKind.IfKeywordToken, "if" },
+        { SyntaxKind.UnlessKeywordToken, "unless" },
+        { SyntaxKind.ElseKeywordToken, "else" },
+        { SyntaxKind.WhileKeywordToken, "while" },
+        { SyntaxKind.UntilKeywordToken, "until" },
+        { SyntaxKind.BreakKeywordToken, "break" },
+        { SyntaxKind.ContinueKeywordToken, "continue" }
+    };
 
-            var tokens = lexer.SyntaxTokens;
-            tokens.Count.Should().Be(6); // '1', '+', '2', '+', '3' and EndOfFileToken
-            tokens.SelectMany(t => t.GetDiagnostics()).Should().BeEmpty();
-        }
+    [Theory]
+    [InlineData("\"\"")]
+    [InlineData("@\"\"")]
+    [InlineData("\"abcd\"")]
+    [InlineData("@\"abcd\"")]
+    [InlineData("\"ab\\tcd\"")]
+    [InlineData("@\"ab\\tcd\"")]
+    [InlineData("\"ab\\\"cd\"")]
+    [InlineData("@\"ab\\\"cd\"")]
+    public void TestStringToken(string text)
+    {
+        var token = LexSingle(text);
+        token.Kind.Should().Be(SyntaxKind.StringToken);
+        token.Text.Should().Be(text);
+    }
 
-        [Theory]
-        [MemberData(nameof(GetTestSingleTokenData))]
-        public void TestSingleToken(SyntaxKind kind, string text)
-        {
-            var token = LexSingle(text);
-            token.Kind.Should().Be(kind);
-            token.Text.Should().Be(text);
-        }
+    [Fact]
+    public void TestSingleLineCommentSimple()
+    {
+        var text = "// comment";
+        var tokens = Lex(text);
+        tokens.Count.Should().Be(1); // eof
 
-        [Fact]
-        public void SingleTokenTestDataShouldCoverAllTokenKinds()
-        {
-            var actualTokenKinds = singleTokenTestData.Keys.ToHashSet();
-            var exemptions = new SyntaxKind[]
-            {
-                SyntaxKind.BadToken,
-                SyntaxKind.EndOfFileToken,
-                SyntaxKind.StringToken,
-                SyntaxKind.NumberToken,
-                SyntaxKind.IdentifierToken,
-                SyntaxKind.WhitespaceTrivia,
-                SyntaxKind.LineBreakTrivia,
-                SyntaxKind.SingleLineCommentTrivia
-            }.ToHashSet();
+        var eof = tokens[0];
+        eof.Kind.Should().Be(SyntaxKind.EndOfFileToken);
+        eof.LeadingTrivia.Count.Should().Be(1);
+        eof.LeadingTrivia.Should().Contain(t => t.Kind == SyntaxKind.SingleLineCommentTrivia
+            && t.Text.ToString() == text);
+    }
 
-            var uncoveredKinds = Enum.GetValues<SyntaxKind>().Except(actualTokenKinds.Union(exemptions));
-            uncoveredKinds.Should().BeEmpty();
-        }
+    [Fact]
+    public void TestSingleLineCommentsWithTokens()
+    {
+        var text = "//A\nreturn 0; //B";
+        var tokens = Lex(text);
+        tokens.Count.Should().Be(4); // return, 0, ;, eof
 
-        public static IEnumerable<object[]> GetTestSingleTokenData()
-            => singleTokenTestData.Select(kv => new object[] { kv.Key, kv.Value });
+        var returnToken = tokens[0];
+        returnToken.Kind.Should().Be(SyntaxKind.ReturnKeywordToken);
+        returnToken.LeadingTrivia.Count.Should().Be(2); // comment, line break
 
-        private static readonly Dictionary<SyntaxKind, string> singleTokenTestData = new()
-        {
-            { SyntaxKind.PlusToken, "+" },
-            { SyntaxKind.PlusPlusToken, "++" },
-            { SyntaxKind.PlusEqualsToken, "+=" },
-            { SyntaxKind.MinusToken, "-" },
-            { SyntaxKind.MinusMinusToken, "--" },
-            { SyntaxKind.MinusEqualsToken, "-=" },
-            { SyntaxKind.StarToken, "*" },
-            { SyntaxKind.StarEqualsToken, "*=" },
-            { SyntaxKind.SlashToken, "/" },
-            { SyntaxKind.SlashEqualsToken, "/=" },
-            { SyntaxKind.OpenParenthesisToken, "(" },
-            { SyntaxKind.CloseParenthesisToken, ")" },
-            { SyntaxKind.EqualsToken, "=" },
-            { SyntaxKind.EqualsEqualsToken, "==" },
-            { SyntaxKind.BangToken, "!" },
-            { SyntaxKind.BangEqualsToken, "!=" },
-            { SyntaxKind.LessThanToken, "<" },
-            { SyntaxKind.LessThanOrEqualsToken, "<=" },
-            { SyntaxKind.GreaterThanToken, ">" },
-            { SyntaxKind.GreaterThanOrEqualsToken, ">=" },
-            { SyntaxKind.AmpersandToken, "&" },
-            { SyntaxKind.AmpersandAmpersandToken, "&&" },
-            { SyntaxKind.PipeToken, "|" },
-            { SyntaxKind.PipePipeToken, "||" },
-            { SyntaxKind.TildeToken, "~" },
-            { SyntaxKind.DotToken, "." },
-            { SyntaxKind.CommaToken, "," },
-            { SyntaxKind.TrueKeywordToken, "true" },
-            { SyntaxKind.FalseKeywordToken, "false" },
-            { SyntaxKind.OpenBraceToken, "{" },
-            { SyntaxKind.CloseBraceToken, "}" },
-            { SyntaxKind.OpenBracketToken, "[" },
-            { SyntaxKind.CloseBracketToken, "]" },
-            { SyntaxKind.SemicolonToken, ";" },
-            { SyntaxKind.ColonToken, ":" },
-            { SyntaxKind.LetKeywordToken, "let" },
-            { SyntaxKind.ConstKeywordToken, "const" },
-            { SyntaxKind.ImportKeywordToken, "import" },
-            { SyntaxKind.FromKeywordToken, "from" },
-            { SyntaxKind.NewKeywordToken, "new" },
-            { SyntaxKind.BoolKeywordToken, "bool" },
-            { SyntaxKind.ByteKeywordToken, "byte" },
-            { SyntaxKind.CharKeywordToken, "char" },
-            { SyntaxKind.IntKeywordToken, "int" },
-            { SyntaxKind.LongKeywordToken, "long" },
-            { SyntaxKind.StringKeywordToken, "string" },
-            { SyntaxKind.VoidKeywordToken, "void" },
-            { SyntaxKind.ReturnKeywordToken, "return" },
-            { SyntaxKind.IfKeywordToken, "if" },
-            { SyntaxKind.UnlessKeywordToken, "unless" },
-            { SyntaxKind.ElseKeywordToken, "else" },
-            { SyntaxKind.WhileKeywordToken, "while" },
-            { SyntaxKind.UntilKeywordToken, "until" },
-            { SyntaxKind.BreakKeywordToken, "break" },
-            { SyntaxKind.ContinueKeywordToken, "continue" }
-        };
+        var a = returnToken.LeadingTrivia[0];
+        a.Kind.Should().Be(SyntaxKind.SingleLineCommentTrivia);
+        a.Text.ToString().Should().Be("//A");
 
-        [Theory]
-        [InlineData("\"\"")]
-        [InlineData("@\"\"")]
-        [InlineData("\"abcd\"")]
-        [InlineData("@\"abcd\"")]
-        [InlineData("\"ab\\tcd\"")]
-        [InlineData("@\"ab\\tcd\"")]
-        [InlineData("\"ab\\\"cd\"")]
-        [InlineData("@\"ab\\\"cd\"")]
-        public void TestStringToken(string text)
-        {
-            var token = LexSingle(text);
-            token.Kind.Should().Be(SyntaxKind.StringToken);
-            token.Text.Should().Be(text);
-        }
+        var commaToken = tokens[2];
+        commaToken.TrailingTrivia.Count.Should().Be(2); // whitespace, comment
 
-        [Fact]
-        public void TestLexerWithDiagnostics()
-        {
-            var sourceText = SourceText.FromString("1+    2 ^+3");
-            var lexer = new Lexer() { SourceText = sourceText };
-            lexer.Lex();
+        var b = commaToken.TrailingTrivia[1];
+        b.Kind.Should().Be(SyntaxKind.SingleLineCommentTrivia);
+        b.Text.ToString().Should().Be("//B");
+    }
 
-            var diagnostics = lexer.SyntaxTokens.SelectMany(t => t.GetDiagnostics()).ToList();
+    [Fact]
+    public void TestLexerWithDiagnostics()
+    {
+        var sourceText = SourceText.FromString("1+    2 ^+3");
+        var lexer = new Lexer() { SourceText = sourceText };
+        lexer.Lex();
 
-            diagnostics.Should().NotBeEmpty();
-            diagnostics.Count.Should().Be(1);
-            diagnostics[0].TextLocation.TextSpan.Start.Should().Be(8);
-            diagnostics[0].TextLocation.TextSpan.Length.Should().Be(0);
-        }
+        var diagnostics = lexer.SyntaxTokens.SelectMany(t => t.GetDiagnostics()).ToList();
+
+        diagnostics.Should().NotBeEmpty();
+        diagnostics.Count.Should().Be(1);
+        diagnostics[0].TextLocation.TextSpan.Start.Should().Be(8);
+        diagnostics[0].TextLocation.TextSpan.Length.Should().Be(0);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -3,517 +3,541 @@ using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+/// <summary>
+/// This lexer converts source texts into syntax tokens, which allows parser to parse into syntax trees later
+/// </summary>
+internal sealed class Lexer
 {
-    /// <summary>
-    /// This lexer converts source texts into syntax tokens, which allows parser to parse into syntax trees later
-    /// </summary>
-    internal sealed class Lexer
+    private readonly List<SyntaxToken> syntaxTokens = new();
+    private int position = 0;
+
+    public SourceText SourceText { get; internal set; }
+
+    private char Current => Seek(0);
+    private char Peak => Seek(1);
+
+    public IReadOnlyList<SyntaxToken> SyntaxTokens => syntaxTokens;
+
+    private char Seek(int offset)
     {
-        private readonly List<SyntaxToken> syntaxTokens = new();
-        private int position = 0;
+        var index = this.position + offset;
 
-        public SourceText SourceText { get; internal set; }
-
-        private char Current => Seek(0);
-        private char Peak => Seek(1);
-
-        public IReadOnlyList<SyntaxToken> SyntaxTokens => syntaxTokens;
-
-        private char Seek(int offset)
+        if (index >= this.SourceText.Text.Length)
         {
-            var index = this.position + offset;
-
-            if (index >= this.SourceText.Text.Length)
-            {
-                return '\0';
-            }
-
-            return this.SourceText.Text[index];
+            return '\0';
         }
 
-        private IReadOnlyCollection<SyntaxTrivia> ReadSyntaxTrivia(bool leading)
+        return this.SourceText.Text[index];
+    }
+
+    private IReadOnlyCollection<SyntaxTrivia> ReadSyntaxTrivia(bool leading)
+    {
+        var triviaList = new List<SyntaxTrivia>();
+
+        var done = false;
+        var start = this.position;
+        var kind = SyntaxKind.BadToken;
+
+        while (!done)
         {
-            var triviaList = new List<SyntaxTrivia>();
-
-            var done = false;
-            var start = this.position;
-            var kind = SyntaxKind.BadToken;
-
-            while (!done)
-            {
-                switch (Current)
-                {
-                    case '\0':
-                        done = true;
-                        break;
-                    case '\n':
-                    case '\r':
-                        done = !leading;
-                        kind = SyntaxKind.LineBreakTrivia;
-                        ReadLineBreak();
-                        break;
-                    case ' ':
-                    case '\t':
-                        kind = SyntaxKind.WhitespaceTrivia;
-                        ReadWhitespace();
-                        break;
-                    default:
-                        done = true;
-                        break;
-                }
-
-                var length = this.position - start;
-
-                if (length > 0)
-                {
-                    triviaList.Add(new SyntaxTrivia(
-                        kind: kind,
-                        text: this.SourceText.GetTextSpan(start, length)
-                    ));
-                }
-            }
-
-            return triviaList;
-        }
-
-        private void ReadLineBreak()
-        {
-            if (Current == '\r' && Peak == '\n')
-            {
-                this.position += 2;
-            }
-            else
-            {
-                ++this.position;
-            }
-        }
-
-        private void ReadWhitespace()
-        {
-            while (true)
-            {
-                if (char.IsWhiteSpace(Current))
-                {
-                    ++this.position;
-                }
-
-                break;
-            }
-        }
-
-        private SyntaxKind ReadNumericLiteral()
-        {
-            while (char.IsDigit(Current)
-                    || (Current == '.' && char.IsDigit(Peak)))
-            {
-                ++position;
-            }
-
-            if (Current == 'f' || Current == 'F' || Current == 'd' || Current == 'D')
-            {
-                ++position;
-            }
-            else
-            {
-                if (Current == 'u' || Current == 'U')
-                {
-                    ++position;
-                }
-
-                if (Current == 'l' || Current == 'L')
-                {
-                    ++position;
-                }
-            }
-
-            return SyntaxKind.NumberToken;
-        }
-
-        private SyntaxKind ReadBinaryNumericLiteral()
-        {
-            position += 2;
-            while (Current == '0' || Current == '1')
-            {
-                ++position;
-            }
-
-            if (Current == 'u' || Current == 'U')
-            {
-                ++position;
-            }
-
-            if (Current == 'l' || Current == 'L')
-            {
-                ++position;
-            }
-
-            return SyntaxKind.NumberToken;
-        }
-
-        private SyntaxKind ReadHexadecimalNumericLiteral()
-        {
-            position += 2;
-
-            while (char.IsDigit(Current)
-                || (Current >= 'a' && Current <= 'f')
-                || (Current >= 'A' && Current <= 'F'))
-            {
-                ++position;
-            }
-
-            if (Current == 'u' || Current == 'U')
-            {
-                ++position;
-            }
-
-            if (Current == 'l' || Current == 'L')
-            {
-                ++position;
-            }
-
-            return SyntaxKind.NumberToken;
-        }
-
-        private (SyntaxKind, ErrorCode) ReadString()
-        {
-            switch (Current)
-            {
-                case '"':
-                    ++this.position;
-                    break;
-                case '@':
-                    this.position += 2;
-                    break;
-            }
-
-            var done = false;
-
-            while (!done)
-            {
-                switch (Current)
-                {
-                    case '\0':
-                    case '\r':
-                    case '\n':
-                        return (SyntaxKind.BadToken, ErrorCode.UnexpectedEndOfFile);
-                    case '"':
-                        ++this.position;
-                        done = true;
-                        break;
-                    case '\\':
-                        if (Peak == '\0')
-                        {
-                            return (SyntaxKind.BadToken, ErrorCode.UnexpectedEndOfFile);
-                        }
-
-                        this.position += 2;
-                        break;
-                    default:
-                        ++this.position;
-                        break;
-                }
-            }
-
-            return (SyntaxKind.StringToken, ErrorCode.Invalid);
-        }
-
-        private SyntaxKind ReadKeywordOrIdentifier()
-        {
-            var start = this.position;
-
-            while (char.IsLetterOrDigit(Current))
-            {
-                ++this.position;
-            }
-
-            var token = this.SourceText.Text[start..this.position];
-            return SyntaxFacts.KeywordMap.GetValueOrDefault(token, SyntaxKind.IdentifierToken);
-        }
-
-        private IReadOnlyCollection<SyntaxTrivia> ReadLeadingSyntaxTrivia() => this.ReadSyntaxTrivia(true);
-        private IReadOnlyCollection<SyntaxTrivia> ReadTrailingSyntaxTrivia() => this.ReadSyntaxTrivia(false);
-
-        private SyntaxToken GetNextToken()
-        {
-            var leadingTrivia = ReadLeadingSyntaxTrivia();
-
-            // read token
-            var start = this.position;
-            var kind = SyntaxKind.BadToken;
-            var errorCode = ErrorCode.UnrecognizedToken;
-
             switch (Current)
             {
                 case '\0':
-                    kind = SyntaxKind.EndOfFileToken;
+                    done = true;
                     break;
-                case '0':
-                    if (Peak == 'b' || Peak == 'B')
-                    {
-                        kind = ReadBinaryNumericLiteral();
-                    }
-                    else if (Peak == 'x' || Peak == 'X')
-                    {
-                        kind = ReadHexadecimalNumericLiteral();
-                    }
-                    else
-                    {
-                        kind = ReadNumericLiteral();
-                    }
+                case '\n':
+                case '\r':
+                    done = !leading;
+                    kind = SyntaxKind.LineBreakTrivia;
+                    ReadLineBreak();
                     break;
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                    kind = ReadNumericLiteral();
-                    break;
-                case '"':
-                    (kind, errorCode) = ReadString();
-                    break;
-                case '@':
-                    if (Peak == '"')
-                    {
-                        (kind, errorCode) = ReadString();
-                    }
-                    break;
-                case '+':
-                    if (Peak == '+')
-                    {
-                        kind = SyntaxKind.PlusPlusToken;
-                        this.position += 2;
-                    }
-                    else if (Peak == '=')
-                    {
-                        kind = SyntaxKind.PlusEqualsToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.PlusToken;
-                        ++this.position;
-                    }
-                    break;
-                case '-':
-                    if (Peak == '-')
-                    {
-                        kind = SyntaxKind.MinusMinusToken;
-                        this.position += 2;
-                    }
-                    else if (Peak == '=')
-                    {
-                        kind = SyntaxKind.MinusEqualsToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.MinusToken;
-                        ++this.position;
-                    }
-                    break;
-                case '*':
-                    if (Peak == '=')
-                    {
-                        kind = SyntaxKind.StarEqualsToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.StarToken;
-                        ++this.position;
-                    }
+                case ' ':
+                case '\t':
+                    kind = SyntaxKind.WhitespaceTrivia;
+                    ReadWhitespace();
                     break;
                 case '/':
-                    if (Peak == '=')
+                    if (Peak == '/')
                     {
-                        kind = SyntaxKind.SlashEqualsToken;
-                        this.position += 2;
+                        kind = SyntaxKind.SingleLineCommentTrivia;
+                        ReadSingleLineComment();
                     }
                     else
                     {
-                        kind = SyntaxKind.SlashToken;
-                        ++this.position;
+                        done = true;
                     }
-                    break;
-                case '(':
-                    kind = SyntaxKind.OpenParenthesisToken;
-                    ++this.position;
-                    break;
-                case ')':
-                    kind = SyntaxKind.CloseParenthesisToken;
-                    ++this.position;
-                    break;
-                case '{':
-                    kind = SyntaxKind.OpenBraceToken;
-                    ++this.position;
-                    break;
-                case '}':
-                    kind = SyntaxKind.CloseBraceToken;
-                    ++this.position;
-                    break;
-                case '[':
-                    kind = SyntaxKind.OpenBracketToken;
-                    ++position;
-                    break;
-                case ']':
-                    kind = SyntaxKind.CloseBracketToken;
-                    ++position;
-                    break;
-                case ';':
-                    kind = SyntaxKind.SemicolonToken;
-                    ++this.position;
-                    break;
-                case ':':
-                    kind = SyntaxKind.ColonToken;
-                    ++this.position;
-                    break;
-                case '=':
-                    if (Peak == '=')
-                    {
-                        kind = SyntaxKind.EqualsEqualsToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.EqualsToken;
-                        ++this.position;
-                    }
-                    break;
-                case '!':
-                    if (Peak == '=')
-                    {
-                        kind = SyntaxKind.BangEqualsToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.BangToken;
-                        ++this.position;
-                    }
-                    break;
-                case '<':
-                    if (Peak == '=')
-                    {
-                        kind = SyntaxKind.LessThanOrEqualsToken;
-                        position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.LessThanToken;
-                        ++position;
-                    }
-                    break;
-                case '>':
-                    if (Peak == '=')
-                    {
-                        kind = SyntaxKind.GreaterThanOrEqualsToken;
-                        position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.GreaterThanToken;
-                        ++position;
-                    }
-                    break;
-                case '&':
-                    if (Peak == '&')
-                    {
-                        kind = SyntaxKind.AmpersandAmpersandToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.AmpersandToken;
-                        ++this.position;
-                    }
-                    break;
-                case '|':
-                    if (Peak == '|')
-                    {
-                        kind = SyntaxKind.PipePipeToken;
-                        this.position += 2;
-                    }
-                    else
-                    {
-                        kind = SyntaxKind.PipeToken;
-                        ++this.position;
-                    }
-                    break;
-                case '~':
-                    kind = SyntaxKind.TildeToken;
-                    ++this.position;
-                    break;
-                case '.':
-                    if (char.IsDigit(Peak))
-                    {
-                        kind = ReadNumericLiteral();
-                        break;
-                    }
-                    kind = SyntaxKind.DotToken;
-                    ++this.position;
-                    break;
-                case ',':
-                    kind = SyntaxKind.CommaToken;
-                    ++this.position;
                     break;
                 default:
-                    // identifiers in todl can only start with a letter and not a digit or underscore
-                    if (char.IsLetter(Current))
-                    {
-                        kind = ReadKeywordOrIdentifier();
-                    }
-
+                    done = true;
                     break;
             }
 
             var length = this.position - start;
 
-            var trailingTrivia = ReadTrailingSyntaxTrivia();
-            var text = SourceText.GetTextSpan(start, length);
-
-            if (kind == SyntaxKind.BadToken)
+            if (length > 0)
             {
-                return new()
-                {
-                    Kind = kind,
-                    Text = text,
-                    LeadingTrivia = leadingTrivia,
-                    TrailingTrivia = trailingTrivia,
-                    ErrorCode = errorCode
-                };
+                triviaList.Add(new SyntaxTrivia(
+                    kind: kind,
+                    text: this.SourceText.GetTextSpan(start, length)));
+            }
+        }
+
+        return triviaList;
+    }
+
+    private void ReadLineBreak()
+    {
+        if (Current == '\r' && Peak == '\n')
+        {
+            this.position += 2;
+        }
+        else
+        {
+            ++this.position;
+        }
+    }
+
+    private void ReadWhitespace()
+    {
+        while (true)
+        {
+            if (char.IsWhiteSpace(Current))
+            {
+                ++this.position;
             }
 
+            break;
+        }
+    }
+
+    private void ReadSingleLineComment()
+    {
+        position += 2; // '//'
+        while (Current != '\r' && Current != '\n' && Current != '\0')
+        {
+            ++position;
+        }
+    }
+
+    private SyntaxKind ReadNumericLiteral()
+    {
+        while (char.IsDigit(Current)
+                || (Current == '.' && char.IsDigit(Peak)))
+        {
+            ++position;
+        }
+
+        if (Current == 'f' || Current == 'F' || Current == 'd' || Current == 'D')
+        {
+            ++position;
+        }
+        else
+        {
+            if (Current == 'u' || Current == 'U')
+            {
+                ++position;
+            }
+
+            if (Current == 'l' || Current == 'L')
+            {
+                ++position;
+            }
+        }
+
+        return SyntaxKind.NumberToken;
+    }
+
+    private SyntaxKind ReadBinaryNumericLiteral()
+    {
+        position += 2;
+        while (Current == '0' || Current == '1')
+        {
+            ++position;
+        }
+
+        if (Current == 'u' || Current == 'U')
+        {
+            ++position;
+        }
+
+        if (Current == 'l' || Current == 'L')
+        {
+            ++position;
+        }
+
+        return SyntaxKind.NumberToken;
+    }
+
+    private SyntaxKind ReadHexadecimalNumericLiteral()
+    {
+        position += 2;
+
+        while (char.IsDigit(Current)
+            || (Current >= 'a' && Current <= 'f')
+            || (Current >= 'A' && Current <= 'F'))
+        {
+            ++position;
+        }
+
+        if (Current == 'u' || Current == 'U')
+        {
+            ++position;
+        }
+
+        if (Current == 'l' || Current == 'L')
+        {
+            ++position;
+        }
+
+        return SyntaxKind.NumberToken;
+    }
+
+    private (SyntaxKind, ErrorCode) ReadString()
+    {
+        switch (Current)
+        {
+            case '"':
+                ++this.position;
+                break;
+            case '@':
+                this.position += 2;
+                break;
+        }
+
+        var done = false;
+
+        while (!done)
+        {
+            switch (Current)
+            {
+                case '\0':
+                case '\r':
+                case '\n':
+                    return (SyntaxKind.BadToken, ErrorCode.UnexpectedEndOfFile);
+                case '"':
+                    ++this.position;
+                    done = true;
+                    break;
+                case '\\':
+                    if (Peak == '\0')
+                    {
+                        return (SyntaxKind.BadToken, ErrorCode.UnexpectedEndOfFile);
+                    }
+
+                    this.position += 2;
+                    break;
+                default:
+                    ++this.position;
+                    break;
+            }
+        }
+
+        return (SyntaxKind.StringToken, ErrorCode.Invalid);
+    }
+
+    private SyntaxKind ReadKeywordOrIdentifier()
+    {
+        var start = this.position;
+
+        while (char.IsLetterOrDigit(Current))
+        {
+            ++this.position;
+        }
+
+        var token = this.SourceText.Text[start..this.position];
+        return SyntaxFacts.KeywordMap.GetValueOrDefault(token, SyntaxKind.IdentifierToken);
+    }
+
+    private IReadOnlyCollection<SyntaxTrivia> ReadLeadingSyntaxTrivia() => this.ReadSyntaxTrivia(true);
+    private IReadOnlyCollection<SyntaxTrivia> ReadTrailingSyntaxTrivia() => this.ReadSyntaxTrivia(false);
+
+    private SyntaxToken GetNextToken()
+    {
+        var leadingTrivia = ReadLeadingSyntaxTrivia();
+
+        // read token
+        var start = this.position;
+        var kind = SyntaxKind.BadToken;
+        var errorCode = ErrorCode.UnrecognizedToken;
+
+        switch (Current)
+        {
+            case '\0':
+                kind = SyntaxKind.EndOfFileToken;
+                break;
+            case '0':
+                if (Peak == 'b' || Peak == 'B')
+                {
+                    kind = ReadBinaryNumericLiteral();
+                }
+                else if (Peak == 'x' || Peak == 'X')
+                {
+                    kind = ReadHexadecimalNumericLiteral();
+                }
+                else
+                {
+                    kind = ReadNumericLiteral();
+                }
+                break;
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                kind = ReadNumericLiteral();
+                break;
+            case '"':
+                (kind, errorCode) = ReadString();
+                break;
+            case '@':
+                if (Peak == '"')
+                {
+                    (kind, errorCode) = ReadString();
+                }
+                break;
+            case '+':
+                if (Peak == '+')
+                {
+                    kind = SyntaxKind.PlusPlusToken;
+                    this.position += 2;
+                }
+                else if (Peak == '=')
+                {
+                    kind = SyntaxKind.PlusEqualsToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.PlusToken;
+                    ++this.position;
+                }
+                break;
+            case '-':
+                if (Peak == '-')
+                {
+                    kind = SyntaxKind.MinusMinusToken;
+                    this.position += 2;
+                }
+                else if (Peak == '=')
+                {
+                    kind = SyntaxKind.MinusEqualsToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.MinusToken;
+                    ++this.position;
+                }
+                break;
+            case '*':
+                if (Peak == '=')
+                {
+                    kind = SyntaxKind.StarEqualsToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.StarToken;
+                    ++this.position;
+                }
+                break;
+            case '/':
+                if (Peak == '=')
+                {
+                    kind = SyntaxKind.SlashEqualsToken;
+                    this.position += 2;
+                }
+                else if (Peak == '/')
+                {
+                    // We always process SingleLineCommentTrivia
+                    // at the end of a token
+                    break;
+                }
+                else
+                {
+                    kind = SyntaxKind.SlashToken;
+                    ++this.position;
+                }
+                break;
+            case '(':
+                kind = SyntaxKind.OpenParenthesisToken;
+                ++this.position;
+                break;
+            case ')':
+                kind = SyntaxKind.CloseParenthesisToken;
+                ++this.position;
+                break;
+            case '{':
+                kind = SyntaxKind.OpenBraceToken;
+                ++this.position;
+                break;
+            case '}':
+                kind = SyntaxKind.CloseBraceToken;
+                ++this.position;
+                break;
+            case '[':
+                kind = SyntaxKind.OpenBracketToken;
+                ++position;
+                break;
+            case ']':
+                kind = SyntaxKind.CloseBracketToken;
+                ++position;
+                break;
+            case ';':
+                kind = SyntaxKind.SemicolonToken;
+                ++this.position;
+                break;
+            case ':':
+                kind = SyntaxKind.ColonToken;
+                ++this.position;
+                break;
+            case '=':
+                if (Peak == '=')
+                {
+                    kind = SyntaxKind.EqualsEqualsToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.EqualsToken;
+                    ++this.position;
+                }
+                break;
+            case '!':
+                if (Peak == '=')
+                {
+                    kind = SyntaxKind.BangEqualsToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.BangToken;
+                    ++this.position;
+                }
+                break;
+            case '<':
+                if (Peak == '=')
+                {
+                    kind = SyntaxKind.LessThanOrEqualsToken;
+                    position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.LessThanToken;
+                    ++position;
+                }
+                break;
+            case '>':
+                if (Peak == '=')
+                {
+                    kind = SyntaxKind.GreaterThanOrEqualsToken;
+                    position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.GreaterThanToken;
+                    ++position;
+                }
+                break;
+            case '&':
+                if (Peak == '&')
+                {
+                    kind = SyntaxKind.AmpersandAmpersandToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.AmpersandToken;
+                    ++this.position;
+                }
+                break;
+            case '|':
+                if (Peak == '|')
+                {
+                    kind = SyntaxKind.PipePipeToken;
+                    this.position += 2;
+                }
+                else
+                {
+                    kind = SyntaxKind.PipeToken;
+                    ++this.position;
+                }
+                break;
+            case '~':
+                kind = SyntaxKind.TildeToken;
+                ++this.position;
+                break;
+            case '.':
+                if (char.IsDigit(Peak))
+                {
+                    kind = ReadNumericLiteral();
+                    break;
+                }
+                kind = SyntaxKind.DotToken;
+                ++this.position;
+                break;
+            case ',':
+                kind = SyntaxKind.CommaToken;
+                ++this.position;
+                break;
+            default:
+                // identifiers in todl can only start with a letter and not a digit or underscore
+                if (char.IsLetter(Current))
+                {
+                    kind = ReadKeywordOrIdentifier();
+                }
+
+                break;
+        }
+
+        var length = this.position - start;
+
+        var trailingTrivia = ReadTrailingSyntaxTrivia();
+        var text = SourceText.GetTextSpan(start, length);
+
+        if (kind == SyntaxKind.BadToken)
+        {
             return new()
             {
                 Kind = kind,
                 Text = text,
                 LeadingTrivia = leadingTrivia,
-                TrailingTrivia = trailingTrivia
+                TrailingTrivia = trailingTrivia,
+                ErrorCode = errorCode
             };
         }
 
-        public void Lex()
+        return new()
         {
-            // if syntaxTokens is not empty, it means lexer has already been executed.
-            if (syntaxTokens.Any())
-            {
-                return;
-            }
+            Kind = kind,
+            Text = text,
+            LeadingTrivia = leadingTrivia,
+            TrailingTrivia = trailingTrivia
+        };
+    }
 
-            SyntaxToken token;
-
-            do
-            {
-                token = GetNextToken();
-                syntaxTokens.Add(token);
-            }
-            while (token.Kind != SyntaxKind.BadToken
-                && token.Kind != SyntaxKind.EndOfFileToken);
+    public void Lex()
+    {
+        // if syntaxTokens is not empty, it means lexer has already been executed.
+        if (syntaxTokens.Any())
+        {
+            return;
         }
+
+        SyntaxToken token;
+
+        do
+        {
+            token = GetNextToken();
+            syntaxTokens.Add(token);
+        }
+        while (token.Kind != SyntaxKind.BadToken
+            && token.Kind != SyntaxKind.EndOfFileToken);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -32,7 +32,7 @@ internal sealed class Lexer
         return this.SourceText.Text[index];
     }
 
-    private IReadOnlyCollection<SyntaxTrivia> ReadSyntaxTrivia(bool leading)
+    private IReadOnlyList<SyntaxTrivia> ReadSyntaxTrivia(bool leading)
     {
         var triviaList = new List<SyntaxTrivia>();
 
@@ -74,14 +74,15 @@ internal sealed class Lexer
                     break;
             }
 
-            var length = this.position - start;
+            var length = position - start;
 
             if (length > 0)
             {
-                triviaList.Add(new SyntaxTrivia(
-                    kind: kind,
-                    text: this.SourceText.GetTextSpan(start, length)));
+                triviaList.Add(
+                    new SyntaxTrivia(kind, SourceText.GetTextSpan(start, length)));
             }
+
+            start = position;
         }
 
         return triviaList;
@@ -250,8 +251,8 @@ internal sealed class Lexer
         return SyntaxFacts.KeywordMap.GetValueOrDefault(token, SyntaxKind.IdentifierToken);
     }
 
-    private IReadOnlyCollection<SyntaxTrivia> ReadLeadingSyntaxTrivia() => this.ReadSyntaxTrivia(true);
-    private IReadOnlyCollection<SyntaxTrivia> ReadTrailingSyntaxTrivia() => this.ReadSyntaxTrivia(false);
+    private IReadOnlyList<SyntaxTrivia> ReadLeadingSyntaxTrivia() => ReadSyntaxTrivia(true);
+    private IReadOnlyList<SyntaxTrivia> ReadTrailingSyntaxTrivia() => ReadSyntaxTrivia(false);
 
     private SyntaxToken GetNextToken()
     {

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -68,6 +68,7 @@
 
         // Trivia
         WhitespaceTrivia,
-        LineBreakTrivia
+        LineBreakTrivia,
+        SingleLineCommentTrivia
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxToken.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxToken.cs
@@ -9,8 +9,8 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
     {
         public SyntaxKind Kind { get; internal init; }
         public TextSpan Text { get; internal init; }
-        public IReadOnlyCollection<SyntaxTrivia> LeadingTrivia { get; internal init; }
-        public IReadOnlyCollection<SyntaxTrivia> TrailingTrivia { get; internal init; }
+        public IReadOnlyList<SyntaxTrivia> LeadingTrivia { get; internal init; }
+        public IReadOnlyList<SyntaxTrivia> TrailingTrivia { get; internal init; }
         public bool Missing { get; internal init; }
         public ErrorCode ErrorCode { get; internal init; }
 

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTrivia.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTrivia.cs
@@ -1,16 +1,5 @@
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
-{
-    public sealed class SyntaxTrivia
-    {
-        public SyntaxKind Kind { get; }
-        public TextSpan Text { get; }
+namespace Todl.Compiler.CodeAnalysis.Syntax;
 
-        public SyntaxTrivia(SyntaxKind kind, TextSpan text)
-        {
-            Kind = kind;
-            Text = text;
-        }
-    }
-}
+public sealed record SyntaxTrivia(SyntaxKind Kind, TextSpan Text) { }


### PR DESCRIPTION
## Summary
This PR adds support for single line comments.

## Detail
Single line comments are pretty common among other programming languages. The usually look like
```
// this is single line comment that takes the entire line
int Main() {
    return 0; // this is another single line comment after normal statements
}

// Additionally, single line comments can also span
// across multiple lines but to the compiler they are
// multiple instances of single line comments.
```