### PR TITLE
Use immutable collections in syntax nodes and other utility classes

### DIFF
--- a/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
@@ -13,13 +14,13 @@ public sealed partial class LexerTests
     private SyntaxToken LexSingle(string text)
     {
         var tokens = Lex(text);
-        tokens.Count.Should().Be(2);
+        tokens.Length.Should().Be(2);
         tokens[0].GetDiagnostics().Should().BeEmpty();
 
         return tokens.First();
     }
 
-    private IReadOnlyList<SyntaxToken> Lex(string text)
+    private ImmutableArray<SyntaxToken> Lex(string text)
     {
         var lexer = new Lexer() { SourceText = SourceText.FromString(text) };
         lexer.Lex();
@@ -36,7 +37,7 @@ public sealed partial class LexerTests
         lexer.Lex();
 
         var tokens = lexer.SyntaxTokens;
-        tokens.Count.Should().Be(6); // '1', '+', '2', '+', '3' and EndOfFileToken
+        tokens.Length.Should().Be(6); // '1', '+', '2', '+', '3' and EndOfFileToken
         tokens.SelectMany(t => t.GetDiagnostics()).Should().BeEmpty();
     }
 
@@ -152,7 +153,7 @@ public sealed partial class LexerTests
     {
         var text = "// comment";
         var tokens = Lex(text);
-        tokens.Count.Should().Be(1); // eof
+        tokens.Length.Should().Be(1); // eof
 
         var eof = tokens[0];
         eof.Kind.Should().Be(SyntaxKind.EndOfFileToken);
@@ -166,7 +167,7 @@ public sealed partial class LexerTests
     {
         var text = "//A\nreturn 0; //B";
         var tokens = Lex(text);
-        tokens.Count.Should().Be(4); // return, 0, ;, eof
+        tokens.Length.Should().Be(4); // return, 0, ;, eof
 
         var returnToken = tokens[0];
         returnToken.Kind.Should().Be(SyntaxKind.ReturnKeywordToken);

--- a/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
@@ -157,7 +157,7 @@ public sealed partial class LexerTests
 
         var eof = tokens[0];
         eof.Kind.Should().Be(SyntaxKind.EndOfFileToken);
-        eof.LeadingTrivia.Count.Should().Be(1);
+        eof.LeadingTrivia.Length.Should().Be(1);
         eof.LeadingTrivia.Should().Contain(t => t.Kind == SyntaxKind.SingleLineCommentTrivia
             && t.Text.ToString() == text);
     }
@@ -171,14 +171,14 @@ public sealed partial class LexerTests
 
         var returnToken = tokens[0];
         returnToken.Kind.Should().Be(SyntaxKind.ReturnKeywordToken);
-        returnToken.LeadingTrivia.Count.Should().Be(2); // comment, line break
+        returnToken.LeadingTrivia.Length.Should().Be(2); // comment, line break
 
         var a = returnToken.LeadingTrivia[0];
         a.Kind.Should().Be(SyntaxKind.SingleLineCommentTrivia);
         a.Text.ToString().Should().Be("//A");
 
         var commaToken = tokens[2];
-        commaToken.TrailingTrivia.Count.Should().Be(2); // whitespace, comment
+        commaToken.TrailingTrivia.Length.Should().Be(2); // whitespace, comment
 
         var b = commaToken.TrailingTrivia[1];
         b.Kind.Should().Be(SyntaxKind.SingleLineCommentTrivia);

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionDeclarationMemberTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionDeclarationMemberTests.cs
@@ -47,7 +47,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             function.Should().NotBeNull();
             function.Name.Text.Should().Be("Function");
             function.ReturnType.Text.Should().Be("void");
-            function.Parameters.Items.Count.Should().Be(1);
+            function.Parameters.Items.Should().HaveCount(1);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var a = function.Parameters.Items[0];
@@ -62,7 +62,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             function.Should().NotBeNull();
             function.Name.Text.Should().Be("Function");
             function.ReturnType.Text.Should().Be("void");
-            function.Parameters.Items.Count.Should().Be(2);
+            function.Parameters.Items.Should().HaveCount(2);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var a = function.Parameters.Items[0];
@@ -81,7 +81,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             function.Should().NotBeNull();
             function.Name.Text.Should().Be("Function");
             function.ReturnType.Text.Should().Be("void");
-            function.Parameters.Items.Count.Should().Be(2);
+            function.Parameters.Items.Should().HaveCount(2);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var a = function.Parameters.Items[0];
@@ -102,7 +102,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             function.Should().NotBeNull();
             function.Name.Text.Should().Be("Function");
             function.ReturnType.Text.Should().Be("void");
-            function.Parameters.Items.Count.Should().Be(3);
+            function.Parameters.Items.Should().HaveCount(3);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var intParameter = function.Parameters.Items[0];

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
@@ -57,6 +57,6 @@ public sealed class WhileUntilStatementTests
         var whileUntilStatement = TestUtils.ParseStatement<WhileUntilStatement>(inputText);
         whileUntilStatement.Should().NotBeNull();
         whileUntilStatement.GetDiagnostics().Should().BeEmpty();
-        whileUntilStatement.BlockStatement.InnerStatements.Count.Should().Be(expectedStatementsCount);
+        whileUntilStatement.BlockStatement.InnerStatements.Should().HaveCount(expectedStatementsCount);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
@@ -67,7 +67,7 @@ public partial class Binder
                 && m.IsStatic == isStatic
                 && !m.ContainsGenericParameters
                 && m.IsPublic
-                && m.GetParameters().Length == functionCallExpression.Arguments.Items.Count);
+                && m.GetParameters().Length == functionCallExpression.Arguments.Items.Length);
 
         var arguments = functionCallExpression.Arguments.Items.ToDictionary(
             keySelector: a => a.Identifier.Value.Text.ToString(),

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
@@ -82,7 +82,7 @@ public partial class Binder
         var clrType = (targetType as ClrTypeSymbol).ClrType;
         var arguments = newExpression.Arguments;
         var candidates = clrType.GetConstructors()
-            .Where(c => c.IsPublic && c.GetParameters().Length == arguments.Items.Count);
+            .Where(c => c.IsPublic && c.GetParameters().Length == arguments.Items.Length);
         var argumentsDictionary = arguments.Items.ToDictionary(
             keySelector: a => a.Identifier.Value.Text.ToString(),
             elementSelector: a => BindExpression(a.Expression));

--- a/src/Todl.Compiler/CodeAnalysis/ClrTypeCacheView.cs
+++ b/src/Todl.Compiler/CodeAnalysis/ClrTypeCacheView.cs
@@ -1,86 +1,86 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
 
-namespace Todl.Compiler.CodeAnalysis
+namespace Todl.Compiler.CodeAnalysis;
+
+public sealed class ClrTypeCacheView
 {
-    public sealed class ClrTypeCacheView
+    private readonly ClrTypeCache clrTypeCache;
+    private readonly ImmutableDictionary<string, ClrTypeSymbol> typeAliases;
+
+    internal ClrTypeSymbol ResolveBaseType(string name)
     {
-        private readonly ClrTypeCache clrTypeCache;
-        private readonly IDictionary<string, ClrTypeSymbol> typeAliases;
-
-        internal ClrTypeSymbol ResolveBaseType(string name)
+        if (string.IsNullOrEmpty(name))
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (typeAliases.ContainsKey(name))
-            {
-                return typeAliases[name];
-            }
-
-            return clrTypeCache.Resolve(name);
+            throw new ArgumentNullException(nameof(name));
         }
 
-        public ClrTypeSymbol ResolveType(NameExpression nameExpression)
-            => ResolveBaseType(nameExpression.Text.ToString());
-
-        public ClrTypeSymbol ResolveType(TypeExpression typeExpression)
+        if (typeAliases.ContainsKey(name))
         {
-            var baseType = ResolveType(typeExpression.BaseTypeExpression);
-            if (!typeExpression.IsArrayType)
-            {
-                return baseType;
-            }
-
-            if (baseType is null)
-            {
-                return null;
-            }
-
-            var resolvedTypeString = typeExpression.Text.ToString().Replace(typeExpression.BaseTypeExpression.Text.ToString(), baseType.Name);
-
-            return new(baseType.ClrType.Assembly.GetType(resolvedTypeString));
+            return typeAliases[name];
         }
 
-        private IDictionary<string, ClrTypeSymbol> ImportTypeAliases(IEnumerable<ImportDirective> importDirectives)
+        return clrTypeCache.Resolve(name);
+    }
+
+    public ClrTypeSymbol ResolveType(NameExpression nameExpression)
+        => ResolveBaseType(nameExpression.Text.ToString());
+
+    public ClrTypeSymbol ResolveType(TypeExpression typeExpression)
+    {
+        var baseType = ResolveType(typeExpression.BaseTypeExpression);
+        if (!typeExpression.IsArrayType)
         {
-            if (importDirectives == null)
+            return baseType;
+        }
+
+        if (baseType is null)
+        {
+            return null;
+        }
+
+        var resolvedTypeString = typeExpression.Text.ToString().Replace(typeExpression.BaseTypeExpression.Text.ToString(), baseType.Name);
+
+        return new(baseType.ClrType.Assembly.GetType(resolvedTypeString));
+    }
+
+    private ImmutableDictionary<string, ClrTypeSymbol> ImportTypeAliases(IEnumerable<ImportDirective> importDirectives)
+    {
+        if (importDirectives == null)
+        {
+            throw new ArgumentNullException(nameof(importDirectives));
+        }
+
+        var importedTypes = importDirectives.SelectMany(importDirective =>
+        {
+            var importedNamespace = importDirective.Namespace.ToString();
+            var types = clrTypeCache
+                .Types
+                .Where(t => importedNamespace.Equals(t.Namespace));
+
+            if (!importDirective.ImportAll)
             {
-                throw new ArgumentNullException(nameof(importDirectives));
+                var importedNames = importDirective
+                    .ImportedNames
+                    .Select(n => $"{importedNamespace}.{n}")
+                    .ToHashSet();
+
+                types = types.Where(t => importedNames.Contains(t.Name));
             }
 
-            var importedTypes = importDirectives.SelectMany(importDirective =>
-            {
-                var importedNamespace = importDirective.Namespace.ToString();
-                var types = clrTypeCache
-                    .Types
-                    .Where(t => importedNamespace.Equals(t.Namespace));
+            return types;
+        }).Distinct();
 
-                if (!importDirective.ImportAll)
-                {
-                    var importedNames = importDirective
-                        .ImportedNames
-                        .Select(n => $"{importedNamespace}.{n}")
-                        .ToHashSet();
+        return importedTypes.ToImmutableDictionary(t => t.ClrType.Name);
+    }
 
-                    types = types.Where(t => importedNames.Contains(t.Name));
-                }
-
-                return types;
-            }).Distinct();
-
-            return importedTypes.ToDictionary(t => t.ClrType.Name);
-        }
-
-        internal ClrTypeCacheView(ClrTypeCache cache, IEnumerable<ImportDirective> importDirectives)
-        {
-            clrTypeCache = cache;
-            typeAliases = ImportTypeAliases(importDirectives);
-        }
+    internal ClrTypeCacheView(ClrTypeCache cache, IEnumerable<ImportDirective> importDirectives)
+    {
+        clrTypeCache = cache;
+        typeAliases = ImportTypeAliases(importDirectives);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Syntax;
 
@@ -8,10 +9,10 @@ namespace Todl.Compiler.CodeAnalysis.Symbols;
 public sealed class FunctionSymbol : Symbol
 {
     public FunctionDeclarationMember FunctionDeclarationMember { get; internal init; }
-    public IEnumerable<ParameterSymbol> Parameters { get; internal init; }
+    public ImmutableArray<ParameterSymbol> Parameters { get; internal init; }
 
-    public IEnumerable<string> OrderedParameterNames
-        => FunctionDeclarationMember.Parameters.Items.Select(p => p.Identifier.Text.ToString());
+    public ImmutableArray<string> OrderedParameterNames
+        => Parameters.Select(p => p.Name).ToImmutableArray();
     public override string Name => FunctionDeclarationMember.Name.Text.ToString();
     public TypeSymbol ReturnType
         => FunctionDeclarationMember.SyntaxTree.ClrTypeCacheView.ResolveType(FunctionDeclarationMember.ReturnType);
@@ -28,7 +29,7 @@ public sealed class FunctionSymbol : Symbol
         return new()
         {
             FunctionDeclarationMember = functionDeclarationMember,
-            Parameters = parameters
+            Parameters = parameters.ToImmutableArray()
         };
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/Symbols/VariableSymbol.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Symbols/VariableSymbol.cs
@@ -1,11 +1,8 @@
-using System;
+﻿namespace Todl.Compiler.CodeAnalysis.Symbols;
 
-namespace Todl.Compiler.CodeAnalysis.Symbols
+public abstract class VariableSymbol : Symbol
 {
-    public abstract class VariableSymbol : Symbol
-    {
-        public abstract bool ReadOnly { get; }
-        public abstract TypeSymbol Type { get; }
-        public virtual bool Constant => false;
-    }
+    public abstract bool ReadOnly { get; }
+    public abstract TypeSymbol Type { get; }
+    public virtual bool Constant => false;
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/AssignmentExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/AssignmentExpression.cs
@@ -1,35 +1,36 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class AssignmentExpression : Expression
 {
-    public sealed class AssignmentExpression : Expression
-    {
-        public Expression Left { get; internal init; }
-        public SyntaxToken AssignmentOperator { get; internal init; }
-        public Expression Right { get; internal init; }
+    public Expression Left { get; internal init; }
+    public SyntaxToken AssignmentOperator { get; internal init; }
+    public Expression Right { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(Left.Text, Right.Text);
+    public override TextSpan Text => TextSpan.FromTextSpans(Left.Text, Right.Text);
 
-        public static readonly IReadOnlySet<SyntaxKind> AssignmentOperators = new HashSet<SyntaxKind>()
-        {
+    public static readonly IReadOnlySet<SyntaxKind> AssignmentOperators
+        = ImmutableHashSet.CreateRange(
+        [
             SyntaxKind.EqualsToken,
             SyntaxKind.PlusEqualsToken,
             SyntaxKind.MinusEqualsToken,
             SyntaxKind.StarEqualsToken,
             SyntaxKind.SlashEqualsToken
-        };
-    }
+        ]);
+}
 
-    public sealed partial class Parser
-    {
-        private AssignmentExpression ParseAssignmentExpression(Expression left)
-            => new()
-            {
-                SyntaxTree = syntaxTree,
-                Left = left,
-                AssignmentOperator = ExpectToken(Current.Kind),
-                Right = ParseExpression()
-            };
-    }
+public sealed partial class Parser
+{
+    private AssignmentExpression ParseAssignmentExpression(Expression left)
+        => new()
+        {
+            SyntaxTree = syntaxTree,
+            Left = left,
+            AssignmentOperator = ExpectToken(Current.Kind),
+            Right = ParseExpression()
+        };
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/BinaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/BinaryExpression.cs
@@ -1,60 +1,60 @@
 ﻿using System.Collections.Generic;
 using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class BinaryExpression : Expression
 {
-    public sealed class BinaryExpression : Expression
-    {
-        public Expression Left { get; internal init; }
-        public Expression Right { get; internal init; }
-        public SyntaxToken Operator { get; internal init; }
+    public Expression Left { get; internal init; }
+    public Expression Right { get; internal init; }
+    public SyntaxToken Operator { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(Left.Text, Right.Text);
-    }
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(Left.Text, Right.Text);
+}
 
-    public sealed partial class Parser
+public sealed partial class Parser
+{
+    private Expression ParseBinaryExpression(int parentPrecedence = 0)
     {
-        private Expression ParseBinaryExpression(int parentPrecedence = 0)
+        Expression left;
+        var unaryPrecedence = SyntaxFacts.UnaryOperatorPrecedence.GetValueOrDefault(Current.Kind, 0);
+        if (unaryPrecedence == 0 || unaryPrecedence <= parentPrecedence)
         {
-            Expression left;
-            var unaryPrecedence = SyntaxFacts.UnaryOperatorPrecedence.GetValueOrDefault(Current.Kind, 0);
-            if (unaryPrecedence == 0 || unaryPrecedence <= parentPrecedence)
-            {
-                left = this.ParsePrimaryExpression();
-            }
-            else
-            {
-                var operatorToken = ExpectToken(Current.Kind);
-                left = new UnaryExpression()
-                {
-                    SyntaxTree = syntaxTree,
-                    Operator = operatorToken,
-                    Operand = ParsePrimaryExpression(),
-                    Trailing = false
-                };
-            }
-
-            while (true)
-            {
-                var binaryPrecedence = SyntaxFacts.BinaryOperatorPrecedence.GetValueOrDefault(Current.Kind, 0);
-                if (binaryPrecedence == 0 || binaryPrecedence <= parentPrecedence)
-                {
-                    break;
-                }
-
-                var operatorToken = this.NextToken();
-                var right = ParseBinaryExpression(binaryPrecedence);
-
-                left = new BinaryExpression()
-                {
-                    SyntaxTree = syntaxTree,
-                    Left = left,
-                    Right = right,
-                    Operator = operatorToken
-                };
-            }
-
-            return left;
+            left = this.ParsePrimaryExpression();
         }
+        else
+        {
+            var operatorToken = ExpectToken(Current.Kind);
+            left = new UnaryExpression()
+            {
+                SyntaxTree = syntaxTree,
+                Operator = operatorToken,
+                Operand = ParsePrimaryExpression(),
+                Trailing = false
+            };
+        }
+
+        while (true)
+        {
+            var binaryPrecedence = SyntaxFacts.BinaryOperatorPrecedence.GetValueOrDefault(Current.Kind, 0);
+            if (binaryPrecedence == 0 || binaryPrecedence <= parentPrecedence)
+            {
+                break;
+            }
+
+            var operatorToken = this.NextToken();
+            var right = ParseBinaryExpression(binaryPrecedence);
+
+            left = new BinaryExpression()
+            {
+                SyntaxTree = syntaxTree,
+                Left = left,
+                Right = right,
+                Operator = operatorToken
+            };
+        }
+
+        return left;
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/CommaSeparatedSyntaxList.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/CommaSeparatedSyntaxList.cs
@@ -1,43 +1,43 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class CommaSeparatedSyntaxList<T> : SyntaxNode where T : SyntaxNode
 {
-    public sealed class CommaSeparatedSyntaxList<T> : SyntaxNode where T : SyntaxNode
-    {
-        public SyntaxToken OpenParenthesisToken { get; internal init; }
-        public IReadOnlyList<T> Items { get; internal init; }
-        public SyntaxToken CloseParenthesisToken { get; internal init; }
+    public SyntaxToken OpenParenthesisToken { get; internal init; }
+    public ImmutableArray<T> Items { get; internal init; }
+    public SyntaxToken CloseParenthesisToken { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(OpenParenthesisToken.Text, CloseParenthesisToken.Text);
-    }
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(OpenParenthesisToken.Text, CloseParenthesisToken.Text);
+}
 
-    public sealed partial class Parser
+public sealed partial class Parser
+{
+    private CommaSeparatedSyntaxList<T> ParseCommaSeparatedSyntaxList<T>(Func<T> parseFunc) where T : SyntaxNode
     {
-        private CommaSeparatedSyntaxList<T> ParseCommaSeparatedSyntaxList<T>(Func<T> parseFunc) where T : SyntaxNode
+        var openParenthesisToken = ExpectToken(SyntaxKind.OpenParenthesisToken);
+        var items = ImmutableArray.CreateBuilder<T>();
+
+        var closeParenthesisToken = ExpectUntil(SyntaxKind.CloseParenthesisToken, () =>
         {
-            var openParenthesisToken = ExpectToken(SyntaxKind.OpenParenthesisToken);
-            var items = new List<T>();
-
-            var closeParenthesisToken = ExpectUntil(SyntaxKind.CloseParenthesisToken, () =>
+            if (Current.Kind == SyntaxKind.CommaToken)
             {
-                if (Current.Kind == SyntaxKind.CommaToken)
-                {
-                    ExpectToken(SyntaxKind.CommaToken);
-                }
+                ExpectToken(SyntaxKind.CommaToken);
+            }
 
-                var item = parseFunc();
-                items.Add(item);
-            });
+            var item = parseFunc();
+            items.Add(item);
+        });
 
-            return new CommaSeparatedSyntaxList<T>()
-            {
-                SyntaxTree = syntaxTree,
-                OpenParenthesisToken = openParenthesisToken,
-                Items = items,
-                CloseParenthesisToken = closeParenthesisToken
-            };
-        }
+        return new()
+        {
+            SyntaxTree = syntaxTree,
+            OpenParenthesisToken = openParenthesisToken,
+            Items = items.ToImmutable(),
+            CloseParenthesisToken = closeParenthesisToken
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Directive.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Directive.cs
@@ -1,10 +1,9 @@
-﻿namespace Todl.Compiler.CodeAnalysis.Syntax
-{
-    public abstract class Directive : SyntaxNode { }
+﻿namespace Todl.Compiler.CodeAnalysis.Syntax;
 
-    public sealed partial class Parser
-    {
-        private Directive ParseDirective()
-            => ParseImportDirective();
-    }
+public abstract class Directive : SyntaxNode { }
+
+public sealed partial class Parser
+{
+    private Directive ParseDirective()
+        => ParseImportDirective();
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Expression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Expression.cs
@@ -1,12 +1,9 @@
-﻿namespace Todl.Compiler.CodeAnalysis.Syntax
-{
-    public abstract class Expression : SyntaxNode { }
+﻿namespace Todl.Compiler.CodeAnalysis.Syntax;
 
-    public sealed partial class Parser
-    {
-        internal Expression ParseExpression()
-        {
-            return ParseBinaryExpression();
-        }
-    }
+public abstract class Expression : SyntaxNode { }
+
+public sealed partial class Parser
+{
+    internal Expression ParseExpression()
+        => ParseBinaryExpression();
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ExpressionStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ExpressionStatement.cs
@@ -1,24 +1,23 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class ExpressionStatement : Statement
 {
-    public sealed class ExpressionStatement : Statement
-    {
-        public Expression Expression { get; internal init; }
-        public SyntaxToken SemicolonToken { get; internal init; }
+    public Expression Expression { get; internal init; }
+    public SyntaxToken SemicolonToken { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(Expression.Text, SemicolonToken.Text);
-    }
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(Expression.Text, SemicolonToken.Text);
+}
 
-    public sealed partial class Parser
-    {
-        private ExpressionStatement ParseExpressionStatement()
-            => new()
-            {
-                SyntaxTree = syntaxTree,
-                Expression = ParseExpression(),
-                SemicolonToken = ExpectToken(SyntaxKind.SemicolonToken)
-            };
-    }
+public sealed partial class Parser
+{
+    private ExpressionStatement ParseExpressionStatement()
+        => new()
+        {
+            SyntaxTree = syntaxTree,
+            Expression = ParseExpression(),
+            SemicolonToken = ExpectToken(SyntaxKind.SemicolonToken)
+        };
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionCallExpression.cs
@@ -1,116 +1,114 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class Argument : SyntaxNode
 {
-    public sealed class Argument : SyntaxNode
+    public SyntaxToken? Identifier { get; internal init; }
+    public SyntaxToken? ColonToken { get; internal init; }
+    public Expression Expression { get; internal init; }
+
+    public bool IsNamedArgument => Identifier.HasValue;
+
+    public override TextSpan Text
     {
-        public SyntaxToken? Identifier { get; internal init; }
-        public SyntaxToken? ColonToken { get; internal init; }
-        public Expression Expression { get; internal init; }
-
-        public bool IsNamedArgument => Identifier.HasValue;
-
-        public override TextSpan Text
+        get
         {
-            get
+            if (IsNamedArgument)
             {
-                if (IsNamedArgument)
-                {
-                    return TextSpan.FromTextSpans(Identifier.Value.Text, Expression.Text);
-                }
-
-                return Expression.Text;
+                return TextSpan.FromTextSpans(Identifier.Value.Text, Expression.Text);
             }
+
+            return Expression.Text;
         }
     }
+}
 
-    public sealed class FunctionCallExpression : Expression
+public sealed class FunctionCallExpression : Expression
+{
+    public Expression BaseExpression { get; internal init; }
+    public SyntaxToken DotToken { get; internal init; }
+    public SyntaxToken NameToken { get; internal init; }
+    public CommaSeparatedSyntaxList<Argument> Arguments { get; internal init; }
+
+    public override TextSpan Text
     {
-        public Expression BaseExpression { get; internal init; }
-        public SyntaxToken DotToken { get; internal init; }
-        public SyntaxToken NameToken { get; internal init; }
-        public CommaSeparatedSyntaxList<Argument> Arguments { get; internal init; }
-
-        public override TextSpan Text
+        get
         {
-            get
+            if (BaseExpression != null)
             {
-                if (BaseExpression != null)
-                {
-                    return TextSpan.FromTextSpans(BaseExpression.Text, Arguments.Text);
-                }
-
-                return TextSpan.FromTextSpans(NameToken.Text, Arguments.Text);
+                return TextSpan.FromTextSpans(BaseExpression.Text, Arguments.Text);
             }
+
+            return TextSpan.FromTextSpans(NameToken.Text, Arguments.Text);
         }
     }
+}
 
-    public sealed partial class Parser
+public sealed partial class Parser
+{
+    private Argument ParseArgument()
     {
-        private Argument ParseArgument()
+        if (Current.Kind == SyntaxKind.IdentifierToken && Peak.Kind == SyntaxKind.ColonToken)
         {
-            if (Current.Kind == SyntaxKind.IdentifierToken && Peak.Kind == SyntaxKind.ColonToken)
-            {
-                return new Argument()
-                {
-                    SyntaxTree = syntaxTree,
-                    Identifier = ExpectToken(SyntaxKind.IdentifierToken),
-                    ColonToken = ExpectToken(SyntaxKind.ColonToken),
-                    Expression = ParseExpression()
-                };
-            }
-
-            return new Argument()
+            return new()
             {
                 SyntaxTree = syntaxTree,
+                Identifier = ExpectToken(SyntaxKind.IdentifierToken),
+                ColonToken = ExpectToken(SyntaxKind.ColonToken),
                 Expression = ParseExpression()
             };
         }
 
-        private FunctionCallExpression ParseFunctionCallExpression(Expression baseExpression)
+        return new()
         {
-            var diagnosticBuilder = new DiagnosticBag.Builder();
-            var arguments = ParseCommaSeparatedSyntaxList(ParseArgument);
+            SyntaxTree = syntaxTree,
+            Expression = ParseExpression()
+        };
+    }
 
-            var namedArguments = arguments.Items.Where(p => p.IsNamedArgument);
-            if (namedArguments.Any() && namedArguments.Count() != arguments.Items.Count)
-            {
-                diagnosticBuilder.Add(
-                    new Diagnostic()
-                    {
-                        Message = "Either all or none of the arguments should be named arguments",
-                        Level = DiagnosticLevel.Error,
-                        TextLocation = arguments.OpenParenthesisToken.GetTextLocation(),
-                        ErrorCode = ErrorCode.MixedPositionalAndNamedArguments
-                    });
-            }
+    private FunctionCallExpression ParseFunctionCallExpression(Expression baseExpression)
+    {
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var arguments = ParseCommaSeparatedSyntaxList(ParseArgument);
 
-            if (baseExpression is MemberAccessExpression memberAccessExpression)
-            {
-                return new FunctionCallExpression()
+        var namedArguments = arguments.Items.Where(p => p.IsNamedArgument);
+        if (namedArguments.Any() && namedArguments.Count() != arguments.Items.Length)
+        {
+            diagnosticBuilder.Add(
+                new Diagnostic()
                 {
-                    SyntaxTree = syntaxTree,
-                    BaseExpression = memberAccessExpression.BaseExpression,
-                    DotToken = memberAccessExpression.DotToken,
-                    NameToken = memberAccessExpression.MemberIdentifierToken,
-                    Arguments = arguments,
-                    DiagnosticBuilder = diagnosticBuilder
-                };
-            }
+                    Message = "Either all or none of the arguments should be named arguments",
+                    Level = DiagnosticLevel.Error,
+                    TextLocation = arguments.OpenParenthesisToken.GetTextLocation(),
+                    ErrorCode = ErrorCode.MixedPositionalAndNamedArguments
+                });
+        }
 
-            Debug.Assert(baseExpression is NameExpression nameExpression && nameExpression.IsSimpleName);
-
+        if (baseExpression is MemberAccessExpression memberAccessExpression)
+        {
             return new FunctionCallExpression()
             {
                 SyntaxTree = syntaxTree,
-                NameToken = (baseExpression as NameExpression).SyntaxTokens[0],
+                BaseExpression = memberAccessExpression.BaseExpression,
+                DotToken = memberAccessExpression.DotToken,
+                NameToken = memberAccessExpression.MemberIdentifierToken,
                 Arguments = arguments,
                 DiagnosticBuilder = diagnosticBuilder
             };
         }
+
+        Debug.Assert(baseExpression is NameExpression nameExpression && nameExpression.IsSimpleName);
+
+        return new()
+        {
+            SyntaxTree = syntaxTree,
+            NameToken = (baseExpression as NameExpression).SyntaxTokens[0],
+            Arguments = arguments,
+            DiagnosticBuilder = diagnosticBuilder
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionDeclarationMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionDeclarationMember.cs
@@ -1,54 +1,52 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class Parameter : SyntaxNode
 {
-    public sealed class Parameter : SyntaxNode
-    {
-        public TypeExpression ParameterType { get; internal init; }
-        public SyntaxToken Identifier { get; internal init; }
+    public TypeExpression ParameterType { get; internal init; }
+    public SyntaxToken Identifier { get; internal init; }
 
-        public override TextSpan Text
-            => TextSpan.FromTextSpans(ParameterType.Text, Identifier.Text);
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(ParameterType.Text, Identifier.Text);
+}
+
+public sealed class FunctionDeclarationMember : Member
+{
+    public TypeExpression ReturnType { get; internal init; }
+    public SyntaxToken Name { get; internal init; }
+    public CommaSeparatedSyntaxList<Parameter> Parameters { get; internal init; }
+    public BlockStatement Body { get; internal init; }
+
+    public override TextSpan Text => TextSpan.FromTextSpans(ReturnType.Text, Body.Text);
+}
+
+public sealed partial class Parser
+{
+    private Parameter ParseParemeter()
+    {
+        return new()
+        {
+            SyntaxTree = syntaxTree,
+            ParameterType = ParseTypeExpression(),
+            Identifier = ExpectToken(SyntaxKind.IdentifierToken)
+        };
     }
 
-    public sealed class FunctionDeclarationMember : Member
+    private FunctionDeclarationMember ParseFunctionDeclarationMember()
     {
-        public TypeExpression ReturnType { get; internal init; }
-        public SyntaxToken Name { get; internal init; }
-        public CommaSeparatedSyntaxList<Parameter> Parameters { get; internal init; }
-        public BlockStatement Body { get; internal init; }
+        var returnType = ParseTypeExpression();
+        var name = ExpectToken(SyntaxKind.IdentifierToken);
+        var parameters = ParseCommaSeparatedSyntaxList(ParseParemeter);
+        var body = ParseBlockStatement();
 
-        public override TextSpan Text => TextSpan.FromTextSpans(ReturnType.Text, Body.Text);
-    }
-
-    public sealed partial class Parser
-    {
-        private Parameter ParseParemeter()
+        return new FunctionDeclarationMember()
         {
-            return new()
-            {
-                SyntaxTree = syntaxTree,
-                ParameterType = ParseTypeExpression(),
-                Identifier = ExpectToken(SyntaxKind.IdentifierToken)
-            };
-        }
-
-        private FunctionDeclarationMember ParseFunctionDeclarationMember()
-        {
-            var returnType = ParseTypeExpression();
-            var name = ExpectToken(SyntaxKind.IdentifierToken);
-            var parameters = ParseCommaSeparatedSyntaxList(ParseParemeter);
-            var body = ParseBlockStatement();
-
-            return new FunctionDeclarationMember()
-            {
-                SyntaxTree = syntaxTree,
-                ReturnType = returnType,
-                Name = name,
-                Parameters = parameters,
-                Body = body
-            };
-        }
+            SyntaxTree = syntaxTree,
+            ReturnType = returnType,
+            Name = name,
+            Parameters = parameters,
+            Body = body
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/IfUnlessStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/IfUnlessStatement.cs
@@ -1,4 +1,5 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
@@ -16,7 +17,7 @@ public sealed class IfUnlessStatement : Statement
     public SyntaxToken IfOrUnlessToken { get; internal init; }
     public Expression ConditionExpression { get; internal init; }
     public BlockStatement BlockStatement { get; internal init; }
-    public IReadOnlyList<ElseClause> ElseClauses { get; internal init; }
+    public ImmutableArray<ElseClause> ElseClauses { get; internal init; }
 
     public override TextSpan Text
         => TextSpan.FromTextSpans(IfOrUnlessToken.Text, BlockStatement.Text);
@@ -45,7 +46,7 @@ public sealed partial class Parser
                 : ExpectToken(SyntaxKind.UnlessKeywordToken);
         var conditionExpression = ParseExpression();
         var blockStatement = ParseBlockStatement();
-        var elseClauses = new List<ElseClause>();
+        var elseClauses = ImmutableArray.CreateBuilder<ElseClause>();
         var diagnosticBuilder = new DiagnosticBag.Builder();
 
         while (Current.Kind == SyntaxKind.ElseKeywordToken)
@@ -104,7 +105,7 @@ public sealed partial class Parser
             IfOrUnlessToken = ifOrUnlessToken,
             ConditionExpression = conditionExpression,
             BlockStatement = blockStatement,
-            ElseClauses = elseClauses,
+            ElseClauses = elseClauses.ToImmutable(),
             DiagnosticBuilder = diagnosticBuilder
         };
     }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ImportDirective.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ImportDirective.cs
@@ -1,88 +1,84 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class ImportDirective : Directive
 {
-    public sealed class ImportDirective : Directive
+    public SyntaxToken ImportKeywordToken { get; internal init; }
+    public SyntaxToken? StarToken { get; internal init; }
+    public SyntaxToken? OpenBraceToken { get; internal init; }
+    public ImmutableArray<SyntaxToken> ImportedTokens { get; internal init; }
+    public SyntaxToken? CloseBraceToken { get; internal init; }
+    public SyntaxToken FromKeywordToken { get; internal init; }
+    public NameExpression NamespaceExpression { get; internal init; }
+    public SyntaxToken SemicolonToken { get; internal init; }
+
+    public bool ImportAll => StarToken != null;
+
+    public TextSpan Namespace => NamespaceExpression.Text;
+
+    public IEnumerable<string> ImportedNames
     {
-        public SyntaxToken ImportKeywordToken { get; internal init; }
-        public SyntaxToken? StarToken { get; internal init; }
-        public SyntaxToken? OpenBraceToken { get; internal init; }
-        public IReadOnlyList<SyntaxToken> ImportedTokens { get; internal init; }
-        public SyntaxToken? CloseBraceToken { get; internal init; }
-        public SyntaxToken FromKeywordToken { get; internal init; }
-        public NameExpression NamespaceExpression { get; internal init; }
-        public SyntaxToken SemicolonToken { get; internal init; }
-
-        public bool ImportAll => StarToken != null;
-
-        public TextSpan Namespace => NamespaceExpression.Text;
-
-        public IEnumerable<string> ImportedNames
+        get
         {
-            get
-            {
-                if (ImportedTokens == null)
-                {
-                    return Array.Empty<string>();
-                }
-
-                return ImportedTokens
-                    .Where(token => token.Kind == SyntaxKind.IdentifierToken)
-                    .Select(token => token.Text.ToString());
-            }
+            return ImportedTokens
+                .Where(token => token.Kind == SyntaxKind.IdentifierToken)
+                .Select(token => token.Text.ToString());
         }
-
-        public override TextSpan Text => TextSpan.FromTextSpans(ImportKeywordToken.Text, SemicolonToken.Text);
     }
 
-    public sealed partial class Parser
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(ImportKeywordToken.Text, SemicolonToken.Text);
+}
+
+public sealed partial class Parser
+{
+    // Supported import directive forms
+    // 1. import { Console } from System;
+    // 2. import { List, Dictionary, LinkedList } from System.Collections.Generic;
+    // 3. import * from System.Threading.Tasks;
+    private ImportDirective ParseImportDirective()
     {
-        // Supported import directive forms
-        // 1. import { Console } from System;
-        // 2. import { List, Dictionary, LinkedList } from System.Collections.Generic;
-        // 3. import * from System.Threading.Tasks;
-        private ImportDirective ParseImportDirective()
+        var importKeyword = ExpectToken(SyntaxKind.ImportKeywordToken);
+        SyntaxToken? starToken = null, openBraceToken = null, closeBraceToken = null;
+        ImmutableArray<SyntaxToken>.Builder importedTokens = null;
+
+        if (Current.Kind == SyntaxKind.StarToken)
         {
-            var importKeyword = ExpectToken(SyntaxKind.ImportKeywordToken);
-            SyntaxToken? starToken = null, openBraceToken = null, closeBraceToken = null;
-            List<SyntaxToken> importedTokens = null;
-
-            if (Current.Kind == SyntaxKind.StarToken)
-            {
-                starToken = ExpectToken(SyntaxKind.StarToken);
-            }
-            else
-            {
-                importedTokens = new List<SyntaxToken>();
-                openBraceToken = ExpectToken(SyntaxKind.OpenBraceToken);
-
-                while (Current.Kind == SyntaxKind.IdentifierToken || Current.Kind == SyntaxKind.CommaToken)
-                {
-                    importedTokens.Add(ExpectToken(Current.Kind));
-                }
-
-                closeBraceToken = ExpectToken(SyntaxKind.CloseBraceToken);
-            }
-
-            var fromKeyword = ExpectToken(SyntaxKind.FromKeywordToken);
-            var namespaceExpression = ParseNameExpression();
-            var semicolonToken = ExpectToken(SyntaxKind.SemicolonToken);
-
-            return new ImportDirective()
-            {
-                SyntaxTree = syntaxTree,
-                ImportKeywordToken = importKeyword,
-                StarToken = starToken,
-                OpenBraceToken = openBraceToken,
-                ImportedTokens = importedTokens,
-                CloseBraceToken = closeBraceToken,
-                FromKeywordToken = fromKeyword,
-                NamespaceExpression = namespaceExpression,
-                SemicolonToken = semicolonToken
-            };
+            starToken = ExpectToken(SyntaxKind.StarToken);
         }
+        else
+        {
+            importedTokens = ImmutableArray.CreateBuilder<SyntaxToken>();
+            openBraceToken = ExpectToken(SyntaxKind.OpenBraceToken);
+
+            while (Current.Kind == SyntaxKind.IdentifierToken || Current.Kind == SyntaxKind.CommaToken)
+            {
+                importedTokens.Add(ExpectToken(Current.Kind));
+            }
+
+            closeBraceToken = ExpectToken(SyntaxKind.CloseBraceToken);
+        }
+
+        var fromKeyword = ExpectToken(SyntaxKind.FromKeywordToken);
+        var namespaceExpression = ParseNameExpression();
+        var semicolonToken = ExpectToken(SyntaxKind.SemicolonToken);
+
+        return new()
+        {
+            SyntaxTree = syntaxTree,
+            ImportKeywordToken = importKeyword,
+            StarToken = starToken,
+            OpenBraceToken = openBraceToken,
+            ImportedTokens = importedTokens is null ? ImmutableArray<SyntaxToken>.Empty : importedTokens.ToImmutable(),
+            CloseBraceToken = closeBraceToken,
+            FromKeywordToken = fromKeyword,
+            NamespaceExpression = namespaceExpression,
+            SemicolonToken = semicolonToken
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
@@ -10,7 +11,9 @@ namespace Todl.Compiler.CodeAnalysis.Syntax;
 /// </summary>
 internal sealed class Lexer
 {
-    private readonly List<SyntaxToken> syntaxTokens = new();
+    private readonly ImmutableArray<SyntaxToken>.Builder syntaxTokens
+        = ImmutableArray.CreateBuilder<SyntaxToken>();
+
     private int position = 0;
 
     public SourceText SourceText { get; internal set; }
@@ -18,7 +21,7 @@ internal sealed class Lexer
     private char Current => Seek(0);
     private char Peak => Seek(1);
 
-    public IReadOnlyList<SyntaxToken> SyntaxTokens => syntaxTokens;
+    public ImmutableArray<SyntaxToken> SyntaxTokens { get; internal set; }
 
     private char Seek(int offset)
     {
@@ -540,5 +543,7 @@ internal sealed class Lexer
         }
         while (token.Kind != SyntaxKind.BadToken
             && token.Kind != SyntaxKind.EndOfFileToken);
+
+        SyntaxTokens = syntaxTokens.ToImmutable();
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -21,7 +21,7 @@ internal sealed class Lexer
     private char Current => Seek(0);
     private char Peak => Seek(1);
 
-    public ImmutableArray<SyntaxToken> SyntaxTokens { get; internal set; }
+    public ImmutableArray<SyntaxToken> SyntaxTokens => syntaxTokens.ToImmutable();
 
     private char Seek(int offset)
     {
@@ -543,7 +543,5 @@ internal sealed class Lexer
         }
         while (token.Kind != SyntaxKind.BadToken
             && token.Kind != SyntaxKind.EndOfFileToken);
-
-        SyntaxTokens = syntaxTokens.ToImmutable();
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -35,9 +35,9 @@ internal sealed class Lexer
         return this.SourceText.Text[index];
     }
 
-    private IReadOnlyList<SyntaxTrivia> ReadSyntaxTrivia(bool leading)
+    private ImmutableArray<SyntaxTrivia> ReadSyntaxTrivia(bool leading)
     {
-        var triviaList = new List<SyntaxTrivia>();
+        var triviaList = ImmutableArray.CreateBuilder<SyntaxTrivia>();
 
         var done = false;
         var start = this.position;
@@ -88,7 +88,7 @@ internal sealed class Lexer
             start = position;
         }
 
-        return triviaList;
+        return triviaList.ToImmutable();
     }
 
     private void ReadLineBreak()
@@ -254,8 +254,8 @@ internal sealed class Lexer
         return SyntaxFacts.KeywordMap.GetValueOrDefault(token, SyntaxKind.IdentifierToken);
     }
 
-    private IReadOnlyList<SyntaxTrivia> ReadLeadingSyntaxTrivia() => ReadSyntaxTrivia(true);
-    private IReadOnlyList<SyntaxTrivia> ReadTrailingSyntaxTrivia() => ReadSyntaxTrivia(false);
+    private ImmutableArray<SyntaxTrivia> ReadLeadingSyntaxTrivia() => ReadSyntaxTrivia(true);
+    private ImmutableArray<SyntaxTrivia> ReadTrailingSyntaxTrivia() => ReadSyntaxTrivia(false);
 
     private SyntaxToken GetNextToken()
     {

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/LiteralExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/LiteralExpression.cs
@@ -1,11 +1,10 @@
 ﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
-{
-    public class LiteralExpression : Expression
-    {
-        public SyntaxToken LiteralToken { get; internal init; }
+namespace Todl.Compiler.CodeAnalysis.Syntax;
 
-        public override TextSpan Text => LiteralToken.Text;
-    }
+public class LiteralExpression : Expression
+{
+    public SyntaxToken LiteralToken { get; internal init; }
+
+    public override TextSpan Text => LiteralToken.Text;
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Member.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Member.cs
@@ -1,17 +1,16 @@
-﻿namespace Todl.Compiler.CodeAnalysis.Syntax
+﻿namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public abstract class Member : SyntaxNode { }
+
+public sealed partial class Parser
 {
-    public abstract class Member : SyntaxNode { }
-
-    public sealed partial class Parser
+    private Member ParseMember()
     {
-        private Member ParseMember()
+        if (Current.Kind == SyntaxKind.ConstKeywordToken || Current.Kind == SyntaxKind.LetKeywordToken)
         {
-            if (Current.Kind == SyntaxKind.ConstKeywordToken || Current.Kind == SyntaxKind.LetKeywordToken)
-            {
-                return ParseVariableDeclarationMember();
-            }
-
-            return ParseFunctionDeclarationMember();
+            return ParseVariableDeclarationMember();
         }
+
+        return ParseFunctionDeclarationMember();
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/MemberAccessExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/MemberAccessExpression.cs
@@ -1,14 +1,13 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class MemberAccessExpression : Expression
 {
-    public sealed class MemberAccessExpression : Expression
-    {
-        public Expression BaseExpression { get; internal init; }
-        public SyntaxToken DotToken { get; internal init; }
-        public SyntaxToken MemberIdentifierToken { get; internal init; }
+    public Expression BaseExpression { get; internal init; }
+    public SyntaxToken DotToken { get; internal init; }
+    public SyntaxToken MemberIdentifierToken { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(BaseExpression.Text, MemberIdentifierToken.Text);
-    }
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(BaseExpression.Text, MemberIdentifierToken.Text);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/NameExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/NameExpression.cs
@@ -1,60 +1,55 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 using System.Text;
 using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class NameExpression : Expression
 {
-    public sealed class NameExpression : Expression
+    public ImmutableArray<SyntaxToken> SyntaxTokens { get; internal init; }
+
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(SyntaxTokens[0].Text, SyntaxTokens[^1].Text);
+
+    public bool IsSimpleName => SyntaxTokens.Length == 1;
+}
+
+public sealed partial class Parser
+{
+    private NameExpression ParseNameExpression()
     {
-        public IReadOnlyList<SyntaxToken> SyntaxTokens { get; internal init; }
-
-        public override TextSpan Text => TextSpan.FromTextSpans(SyntaxTokens[0].Text, SyntaxTokens[^1].Text);
-
-        public bool IsSimpleName => SyntaxTokens.Count == 1;
-    }
-
-    public sealed partial class Parser
-    {
-        private NameExpression ParseNameExpression()
+        if (SyntaxFacts.BuiltInTypes.Contains(Current.Kind))
         {
-            if (SyntaxFacts.BuiltInTypes.Contains(Current.Kind))
-            {
-                return new NameExpression()
-                {
-                    SyntaxTree = syntaxTree,
-                    SyntaxTokens = new List<SyntaxToken>()
-                    {
-                        ExpectToken(Current.Kind)
-                    }
-                };
-            }
-
-            var syntaxTokens = new List<SyntaxToken>
-            {
-                ExpectToken(SyntaxKind.IdentifierToken)
-            };
-
-            var builder = new StringBuilder(syntaxTokens[0].Text.ToString());
-
-            while (Current.Kind == SyntaxKind.DotToken && Peak.Kind == SyntaxKind.IdentifierToken)
-            {
-                if (!syntaxTree.ClrTypeCache.Namespaces.Contains(builder.ToString()))
-                {
-                    break;
-                }
-
-                syntaxTokens.Add(ExpectToken(SyntaxKind.DotToken));
-
-                var identifierToken = ExpectToken(SyntaxKind.IdentifierToken);
-                syntaxTokens.Add(identifierToken);
-                builder.Append($".{identifierToken.Text}");
-            }
-
-            return new NameExpression()
+            return new()
             {
                 SyntaxTree = syntaxTree,
-                SyntaxTokens = syntaxTokens
+                SyntaxTokens = ImmutableArray.CreateRange([ExpectToken(Current.Kind)])
             };
         }
+
+        var syntaxTokens = ImmutableArray.CreateBuilder<SyntaxToken>();
+        syntaxTokens.Add(ExpectToken(SyntaxKind.IdentifierToken));
+
+        var builder = new StringBuilder(syntaxTokens[0].Text.ToString());
+
+        while (Current.Kind == SyntaxKind.DotToken && Peak.Kind == SyntaxKind.IdentifierToken)
+        {
+            if (!syntaxTree.ClrTypeCache.Namespaces.Contains(builder.ToString()))
+            {
+                break;
+            }
+
+            syntaxTokens.Add(ExpectToken(SyntaxKind.DotToken));
+
+            var identifierToken = ExpectToken(SyntaxKind.IdentifierToken);
+            syntaxTokens.Add(identifierToken);
+            builder.Append($".{identifierToken.Text}");
+        }
+
+        return new()
+        {
+            SyntaxTree = syntaxTree,
+            SyntaxTokens = syntaxTokens.ToImmutable()
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/NewExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/NewExpression.cs
@@ -1,49 +1,47 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class NewExpression : Expression
 {
-    public sealed class NewExpression : Expression
-    {
-        public SyntaxToken NewKeywordToken { get; internal init; }
-        public NameExpression TypeNameExpression { get; internal init; }
-        public CommaSeparatedSyntaxList<Argument> Arguments { get; internal init; }
+    public SyntaxToken NewKeywordToken { get; internal init; }
+    public NameExpression TypeNameExpression { get; internal init; }
+    public CommaSeparatedSyntaxList<Argument> Arguments { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(NewKeywordToken.Text, Arguments.Text);
-    }
+    public override TextSpan Text => TextSpan.FromTextSpans(NewKeywordToken.Text, Arguments.Text);
+}
 
-    public sealed partial class Parser
+public sealed partial class Parser
+{
+    private NewExpression ParseNewExpression()
     {
-        private NewExpression ParseNewExpression()
+        var diagnosticsBuilder = new DiagnosticBag.Builder();
+        var newKeywordToken = ExpectToken(SyntaxKind.NewKeywordToken);
+        var typeNameExpression = ParseNameExpression();
+        var arguments = ParseCommaSeparatedSyntaxList(ParseArgument);
+
+        var namedArguments = arguments.Items.Where(p => p.IsNamedArgument);
+        if (namedArguments.Any() && namedArguments.Count() != arguments.Items.Length)
         {
-            var diagnosticsBuilder = new DiagnosticBag.Builder();
-            var newKeywordToken = ExpectToken(SyntaxKind.NewKeywordToken);
-            var typeNameExpression = ParseNameExpression();
-            var arguments = ParseCommaSeparatedSyntaxList(ParseArgument);
-
-            var namedArguments = arguments.Items.Where(p => p.IsNamedArgument);
-            if (namedArguments.Any() && namedArguments.Count() != arguments.Items.Count)
-            {
-                diagnosticsBuilder.Add(
-                    new Diagnostic()
-                    {
-                        Message = "Either all or none of the arguments should be named arguments",
-                        Level = DiagnosticLevel.Error,
-                        TextLocation = arguments.OpenParenthesisToken.GetTextLocation(),
-                        ErrorCode = ErrorCode.MixedPositionalAndNamedArguments
-                    });
-            }
-
-            return new NewExpression()
-            {
-                SyntaxTree = syntaxTree,
-                NewKeywordToken = newKeywordToken,
-                TypeNameExpression = typeNameExpression,
-                Arguments = arguments,
-                DiagnosticBuilder = diagnosticsBuilder
-            };
+            diagnosticsBuilder.Add(
+                new Diagnostic()
+                {
+                    Message = "Either all or none of the arguments should be named arguments",
+                    Level = DiagnosticLevel.Error,
+                    TextLocation = arguments.OpenParenthesisToken.GetTextLocation(),
+                    ErrorCode = ErrorCode.MixedPositionalAndNamedArguments
+                });
         }
+
+        return new NewExpression()
+        {
+            SyntaxTree = syntaxTree,
+            NewKeywordToken = newKeywordToken,
+            TypeNameExpression = typeNameExpression,
+            Arguments = arguments,
+            DiagnosticBuilder = diagnosticsBuilder
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ParethesizedExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ParethesizedExpression.cs
@@ -1,26 +1,25 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class ParethesizedExpression : Expression
 {
-    public sealed class ParethesizedExpression : Expression
-    {
-        public SyntaxToken LeftParenthesisToken { get; internal init; }
-        public Expression InnerExpression { get; internal init; }
-        public SyntaxToken RightParenthesisToken { get; internal init; }
+    public SyntaxToken LeftParenthesisToken { get; internal init; }
+    public Expression InnerExpression { get; internal init; }
+    public SyntaxToken RightParenthesisToken { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(LeftParenthesisToken.Text, RightParenthesisToken.Text);
-    }
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(LeftParenthesisToken.Text, RightParenthesisToken.Text);
+}
 
-    public sealed partial class Parser
-    {
-        private ParethesizedExpression ParseParethesizedExpression()
-            => new()
-            {
-                SyntaxTree = syntaxTree,
-                LeftParenthesisToken = ExpectToken(SyntaxKind.OpenParenthesisToken),
-                InnerExpression = ParseBinaryExpression(),
-                RightParenthesisToken = ExpectToken(SyntaxKind.CloseParenthesisToken)
-            };
-    }
+public sealed partial class Parser
+{
+    private ParethesizedExpression ParseParethesizedExpression()
+        => new()
+        {
+            SyntaxTree = syntaxTree,
+            LeftParenthesisToken = ExpectToken(SyntaxKind.OpenParenthesisToken),
+            InnerExpression = ParseBinaryExpression(),
+            RightParenthesisToken = ExpectToken(SyntaxKind.CloseParenthesisToken)
+        };
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
@@ -12,27 +10,30 @@ namespace Todl.Compiler.CodeAnalysis.Syntax;
 public sealed partial class Parser
 {
     private readonly SyntaxTree syntaxTree;
-    private readonly List<Directive> directives = new();
-    private readonly List<Member> members = new();
+    private readonly ImmutableArray<Directive>.Builder directives
+        = ImmutableArray.CreateBuilder<Directive>();
+    private readonly ImmutableArray<Member>.Builder members
+        = ImmutableArray.CreateBuilder<Member>();
+
     private int position = 0;
 
-    private IReadOnlyList<SyntaxToken> SyntaxTokens => syntaxTree.SyntaxTokens;
+    private ImmutableArray<SyntaxToken> SyntaxTokens => syntaxTree.SyntaxTokens;
 
     private SyntaxToken Current => Seek(0);
     private SyntaxToken Peak => Seek(1);
 
-    public IReadOnlyList<Directive> Directives => directives;
-    public IReadOnlyList<Member> Members => members;
+    public ImmutableArray<Directive> Directives => directives.ToImmutable();
+    public ImmutableArray<Member> Members => members.ToImmutable();
 
     private SyntaxToken Seek(int offset)
     {
-        var index = this.position + offset;
-        if (index >= this.SyntaxTokens.Count)
+        var index = position + offset;
+        if (index >= SyntaxTokens.Length)
         {
-            return this.SyntaxTokens[SyntaxTokens.Count - 1];
+            return SyntaxTokens[^1];
         }
 
-        return this.SyntaxTokens[index];
+        return SyntaxTokens[index];
     }
 
     private SyntaxToken NextToken()

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
@@ -1,168 +1,168 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.Diagnostics;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+/// <summary>
+/// This class implements a recursive descent parser for the todl language
+/// </summary>
+public sealed partial class Parser
 {
-    /// <summary>
-    /// This class implements a recursive descent parser for the todl language
-    /// </summary>
-    public sealed partial class Parser
+    private readonly SyntaxTree syntaxTree;
+    private readonly List<Directive> directives = new();
+    private readonly List<Member> members = new();
+    private int position = 0;
+
+    private IReadOnlyList<SyntaxToken> SyntaxTokens => syntaxTree.SyntaxTokens;
+
+    private SyntaxToken Current => Seek(0);
+    private SyntaxToken Peak => Seek(1);
+
+    public IReadOnlyList<Directive> Directives => directives;
+    public IReadOnlyList<Member> Members => members;
+
+    private SyntaxToken Seek(int offset)
     {
-        private readonly SyntaxTree syntaxTree;
-        private readonly List<Directive> directives = new();
-        private readonly List<Member> members = new();
-        private int position = 0;
-
-        private IReadOnlyList<SyntaxToken> SyntaxTokens => syntaxTree.SyntaxTokens;
-
-        private SyntaxToken Current => Seek(0);
-        private SyntaxToken Peak => Seek(1);
-
-        public IReadOnlyList<Directive> Directives => directives;
-        public IReadOnlyList<Member> Members => members;
-
-        private SyntaxToken Seek(int offset)
+        var index = this.position + offset;
+        if (index >= this.SyntaxTokens.Count)
         {
-            var index = this.position + offset;
-            if (index >= this.SyntaxTokens.Count)
+            return this.SyntaxTokens[SyntaxTokens.Count - 1];
+        }
+
+        return this.SyntaxTokens[index];
+    }
+
+    private SyntaxToken NextToken()
+    {
+        var current = this.Current;
+        ++this.position;
+        return current;
+    }
+
+    private SyntaxToken ExpectToken(SyntaxKind syntaxKind)
+    {
+        if (Current.Kind == syntaxKind)
+        {
+            return NextToken();
+        }
+
+        return ReportUnexpectedToken(syntaxKind);
+    }
+
+    private SyntaxToken ExpectUntil(SyntaxKind syntaxKind, Action action)
+    {
+        while (Current.Kind != syntaxKind
+            && Current.Kind != SyntaxKind.EndOfFileToken
+            && Current.Kind != SyntaxKind.BadToken)
+        {
+            var oldPosition = position;
+
+            action();
+
+            // if the action hasn't taken any tokens it's unlikely that it will ever do so
+            // in the following rounds, this could cause an infinite loop.
+            if (position == oldPosition)
             {
-                return this.SyntaxTokens[SyntaxTokens.Count - 1];
+                break;
             }
-
-            return this.SyntaxTokens[index];
         }
 
-        private SyntaxToken NextToken()
+        return ExpectToken(syntaxKind);
+    }
+
+    internal Parser(SyntaxTree syntaxTree)
+    {
+        this.syntaxTree = syntaxTree;
+    }
+
+    public void Parse()
+    {
+        while (Current.Kind == SyntaxKind.ImportKeywordToken)
         {
-            var current = this.Current;
-            ++this.position;
-            return current;
+            directives.Add(ParseDirective());
         }
 
-        private SyntaxToken ExpectToken(SyntaxKind syntaxKind)
+        while (Current.Kind != SyntaxKind.EndOfFileToken
+            && Current.Kind != SyntaxKind.BadToken)
         {
-            if (Current.Kind == syntaxKind)
-            {
-                return NextToken();
-            }
-
-            return ReportUnexpectedToken(syntaxKind);
+            members.Add(ParseMember());
         }
+    }
 
-        private SyntaxToken ExpectUntil(SyntaxKind syntaxKind, Action action)
+    private Expression ParsePrimaryExpression()
+    {
+        Expression baseExpression;
+
+        switch (Current.Kind)
         {
-            while (Current.Kind != syntaxKind
-                && Current.Kind != SyntaxKind.EndOfFileToken
-                && Current.Kind != SyntaxKind.BadToken)
-            {
-                var oldPosition = position;
-
-                action();
-
-                // if the action hasn't taken any tokens it's unlikely that it will ever do so
-                // in the following rounds, this could cause an infinite loop.
-                if (position == oldPosition)
+            case SyntaxKind.NumberToken:
+            case SyntaxKind.StringToken:
+            case SyntaxKind.TrueKeywordToken:
+            case SyntaxKind.FalseKeywordToken:
+                baseExpression = new LiteralExpression()
                 {
-                    break;
-                }
-            }
+                    SyntaxTree = syntaxTree,
+                    LiteralToken = ExpectToken(Current.Kind)
+                };
+                break;
+            case SyntaxKind.OpenParenthesisToken:
+                baseExpression = ParseTrailingUnaryExpression(this.ParseParethesizedExpression());
+                break;
+            case SyntaxKind.NewKeywordToken:
+                baseExpression = ParseNewExpression();
+                break;
+            case SyntaxKind.IdentifierToken:
+            default:
+                var nameExpression = ParseNameExpression();
+                baseExpression = ParseTrailingUnaryExpression(nameExpression);
 
-            return ExpectToken(syntaxKind);
+                break;
         }
 
-        internal Parser(SyntaxTree syntaxTree)
+        while (true)
         {
-            this.syntaxTree = syntaxTree;
+            if (AssignmentExpression.AssignmentOperators.Contains(Current.Kind))
+            {
+                baseExpression = ParseAssignmentExpression(baseExpression);
+            }
+            else if (Current.Kind == SyntaxKind.DotToken && Peak.Kind == SyntaxKind.IdentifierToken)
+            {
+                baseExpression = ParseTrailingUnaryExpression(new MemberAccessExpression()
+                {
+                    SyntaxTree = syntaxTree,
+                    BaseExpression = baseExpression,
+                    DotToken = ExpectToken(SyntaxKind.DotToken),
+                    MemberIdentifierToken = ExpectToken(SyntaxKind.IdentifierToken)
+                });
+            }
+            else if (Current.Kind == SyntaxKind.OpenParenthesisToken)
+            {
+                baseExpression = ParseFunctionCallExpression(baseExpression);
+                break;
+            }
+            else
+            {
+                break;
+            }
         }
 
-        public void Parse()
+        return baseExpression;
+    }
+
+    private SyntaxToken ReportUnexpectedToken(SyntaxKind expectedSyntaxKind)
+    {
+        // return a fake syntax token of the expected kind, with a text span at the current location with 0 length 
+        return new()
         {
-            while (Current.Kind == SyntaxKind.ImportKeywordToken)
-            {
-                directives.Add(ParseDirective());
-            }
-
-            while (Current.Kind != SyntaxKind.EndOfFileToken
-                && Current.Kind != SyntaxKind.BadToken)
-            {
-                members.Add(ParseMember());
-            }
-        }
-
-        private Expression ParsePrimaryExpression()
-        {
-            Expression baseExpression;
-
-            switch (Current.Kind)
-            {
-                case SyntaxKind.NumberToken:
-                case SyntaxKind.StringToken:
-                case SyntaxKind.TrueKeywordToken:
-                case SyntaxKind.FalseKeywordToken:
-                    baseExpression = new LiteralExpression()
-                    {
-                        SyntaxTree = syntaxTree,
-                        LiteralToken = ExpectToken(Current.Kind)
-                    };
-                    break;
-                case SyntaxKind.OpenParenthesisToken:
-                    baseExpression = ParseTrailingUnaryExpression(this.ParseParethesizedExpression());
-                    break;
-                case SyntaxKind.NewKeywordToken:
-                    baseExpression = ParseNewExpression();
-                    break;
-                case SyntaxKind.IdentifierToken:
-                default:
-                    var nameExpression = ParseNameExpression();
-                    baseExpression = ParseTrailingUnaryExpression(nameExpression);
-
-                    break;
-            }
-
-            while (true)
-            {
-                if (AssignmentExpression.AssignmentOperators.Contains(Current.Kind))
-                {
-                    baseExpression = ParseAssignmentExpression(baseExpression);
-                }
-                else if (Current.Kind == SyntaxKind.DotToken && Peak.Kind == SyntaxKind.IdentifierToken)
-                {
-                    baseExpression = ParseTrailingUnaryExpression(new MemberAccessExpression()
-                    {
-                        SyntaxTree = syntaxTree,
-                        BaseExpression = baseExpression,
-                        DotToken = ExpectToken(SyntaxKind.DotToken),
-                        MemberIdentifierToken = ExpectToken(SyntaxKind.IdentifierToken)
-                    });
-                }
-                else if (Current.Kind == SyntaxKind.OpenParenthesisToken)
-                {
-                    baseExpression = ParseFunctionCallExpression(baseExpression);
-                    break;
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            return baseExpression;
-        }
-
-        private SyntaxToken ReportUnexpectedToken(SyntaxKind expectedSyntaxKind)
-        {
-            // return a fake syntax token of the expected kind, with a text span at the current location with 0 length 
-            return new()
-            {
-                Kind = expectedSyntaxKind,
-                Text = syntaxTree.SourceText.GetTextSpan(Current.Text.Start, 0),
-                LeadingTrivia = Array.Empty<SyntaxTrivia>(),
-                TrailingTrivia = Array.Empty<SyntaxTrivia>(),
-                Missing = true,
-                ErrorCode = ErrorCode.UnexpectedToken
-            };
-        }
+            Kind = expectedSyntaxKind,
+            Text = syntaxTree.SourceText.GetTextSpan(Current.Text.Start, 0),
+            LeadingTrivia = ImmutableArray<SyntaxTrivia>.Empty,
+            TrailingTrivia = ImmutableArray<SyntaxTrivia>.Empty,
+            Missing = true,
+            ErrorCode = ErrorCode.UnexpectedToken
+        };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ReturnStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ReturnStatement.cs
@@ -8,7 +8,8 @@ public sealed class ReturnStatement : Statement
     public Expression ReturnValueExpression { get; internal init; }
     public SyntaxToken SemicolonToken { get; internal init; }
 
-    public override TextSpan Text => TextSpan.FromTextSpans(ReturnKeywordToken.Text, SemicolonToken.Text);
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(ReturnKeywordToken.Text, SemicolonToken.Text);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTrivia.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTrivia.cs
@@ -2,4 +2,4 @@
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
 
-public sealed record SyntaxTrivia(SyntaxKind Kind, TextSpan Text) { }
+public readonly record struct SyntaxTrivia(SyntaxKind Kind, TextSpan Text) { }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/TypeExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/TypeExpression.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 
@@ -7,7 +7,7 @@ namespace Todl.Compiler.CodeAnalysis.Syntax;
 public sealed class TypeExpression : Expression
 {
     public NameExpression BaseTypeExpression { get; internal init; }
-    public IReadOnlyList<ArrayRankSpecifier> ArrayRankSpecifiers { get; internal init; }
+    public ImmutableArray<ArrayRankSpecifier> ArrayRankSpecifiers { get; internal init; }
 
     public bool IsArrayType => ArrayRankSpecifiers.Any();
 
@@ -30,7 +30,7 @@ public sealed partial class Parser
     private TypeExpression ParseTypeExpression()
     {
         var nameExpression = ParseNameExpression();
-        var arrayRankSpecifiers = new List<ArrayRankSpecifier>();
+        var arrayRankSpecifiers = ImmutableArray.CreateBuilder<ArrayRankSpecifier>();
 
         while (Current.Kind == SyntaxKind.OpenBracketToken)
         {
@@ -40,7 +40,7 @@ public sealed partial class Parser
         return new()
         {
             BaseTypeExpression = nameExpression,
-            ArrayRankSpecifiers = arrayRankSpecifiers
+            ArrayRankSpecifiers = arrayRankSpecifiers.ToImmutable()
         };
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/UnaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/UnaryExpression.cs
@@ -1,44 +1,42 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class UnaryExpression : Expression
 {
-    public sealed class UnaryExpression : Expression
+    public SyntaxToken Operator { get; internal init; }
+    public Expression Operand { get; internal init; }
+    public bool Trailing { get; internal init; }
+
+    public override TextSpan Text
     {
-        public SyntaxToken Operator { get; internal init; }
-        public Expression Operand { get; internal init; }
-        public bool Trailing { get; internal init; }
-
-        public override TextSpan Text
+        get
         {
-            get
+            if (Trailing)
             {
-                if (Trailing)
-                {
-                    return TextSpan.FromTextSpans(Operand.Text, Operator.Text);
-                }
-
-                return TextSpan.FromTextSpans(Operator.Text, Operand.Text);
+                return TextSpan.FromTextSpans(Operand.Text, Operator.Text);
             }
+
+            return TextSpan.FromTextSpans(Operator.Text, Operand.Text);
         }
     }
+}
 
-    public sealed partial class Parser
+public sealed partial class Parser
+{
+    private Expression ParseTrailingUnaryExpression(Expression expression)
     {
-        private Expression ParseTrailingUnaryExpression(Expression expression)
+        if (Current.Kind == SyntaxKind.PlusPlusToken || Current.Kind == SyntaxKind.MinusMinusToken)
         {
-            if (Current.Kind == SyntaxKind.PlusPlusToken || Current.Kind == SyntaxKind.MinusMinusToken)
+            return new UnaryExpression()
             {
-                return new UnaryExpression()
-                {
-                    SyntaxTree = syntaxTree,
-                    Operator = ExpectToken(Current.Kind),
-                    Operand = expression,
-                    Trailing = true
-                };
-            }
-
-            return expression;
+                SyntaxTree = syntaxTree,
+                Operator = ExpectToken(Current.Kind),
+                Operand = expression,
+                Trailing = true
+            };
         }
+
+        return expression;
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/VariableDeclarationMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/VariableDeclarationMember.cs
@@ -1,22 +1,20 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public sealed class VariableDeclarationMember : Member
 {
-    public sealed class VariableDeclarationMember : Member
-    {
-        public VariableDeclarationStatement VariableDeclarationStatement { get; init; }
+    public VariableDeclarationStatement VariableDeclarationStatement { get; init; }
 
-        public override TextSpan Text => VariableDeclarationStatement.Text;
-    }
+    public override TextSpan Text => VariableDeclarationStatement.Text;
+}
 
-    public sealed partial class Parser
-    {
-        private VariableDeclarationMember ParseVariableDeclarationMember()
-            => new()
-            {
-                SyntaxTree = syntaxTree,
-                VariableDeclarationStatement = ParseVariableDeclarationStatement()
-            };
-    }
+public sealed partial class Parser
+{
+    private VariableDeclarationMember ParseVariableDeclarationMember()
+        => new()
+        {
+            SyntaxTree = syntaxTree,
+            VariableDeclarationStatement = ParseVariableDeclarationStatement()
+        };
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/VariableDeclarationStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/VariableDeclarationStatement.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax
 {
@@ -14,7 +13,8 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
         public Expression InitializerExpression { get; internal init; }
         public SyntaxToken SemicolonToken { get; internal init; }
 
-        public override TextSpan Text => TextSpan.FromTextSpans(DeclarationKeyword.Text, SemicolonToken.Text);
+        public override TextSpan Text
+            => TextSpan.FromTextSpans(DeclarationKeyword.Text, SemicolonToken.Text);
     }
 
     public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Text/TextLocation.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Text/TextLocation.cs
@@ -1,7 +1,3 @@
-﻿namespace Todl.Compiler.CodeAnalysis.Text
-{
-    public struct TextLocation
-    {
-        public TextSpan TextSpan { get; internal init; }
-    }
-}
+﻿namespace Todl.Compiler.CodeAnalysis.Text;
+
+public record struct TextLocation(TextSpan TextSpan);


### PR DESCRIPTION
Following from the practices of Roslyn, `ImmutableArray` and `ImmutableDictionary` is now the default collection types used in syntax nodes and other utility classes. 