### PR TITLE
Use immutable collections for bound nodes

### DIFF
--- a/src/Todl.Compiler.SourceGenerators/BoundNodeFactorySourceGenerator.cs
+++ b/src/Todl.Compiler.SourceGenerators/BoundNodeFactorySourceGenerator.cs
@@ -34,6 +34,7 @@ internal sealed class BoundNodeFactorySourceGenerator : IIncrementalGenerator
                 using System;
                 using System.CodeDom.Compiler;
                 using System.Collections.Generic;
+                using System.Collections.Immutable;
                 using System.Reflection;
                 using Todl.Compiler.CodeAnalysis.Symbols;
                 using Todl.Compiler.CodeAnalysis.Syntax;

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BinderTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BinderTests.cs
@@ -21,7 +21,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var boundBlockStatement = TestUtils.BindStatement<BoundBlockStatement>(input);
 
             boundBlockStatement.Should().NotBeNull();
-            boundBlockStatement.Statements.Count.Should().Be(2);
+            boundBlockStatement.Statements.Should().HaveCount(2);
             boundBlockStatement.Scope.LookupVariable("a").Type.SpecialType.Should().Be(SpecialType.ClrInt32);
             boundBlockStatement.Scope.LookupVariable("b").Type.SpecialType.Should().Be(SpecialType.ClrInt32);
 
@@ -45,7 +45,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var boundBlockStatement = TestUtils.BindStatement<BoundBlockStatement>(input);
 
             boundBlockStatement.Should().NotBeNull();
-            boundBlockStatement.Statements.Count.Should().Be(2);
+            boundBlockStatement.Statements.Should().HaveCount(2);
             boundBlockStatement.Scope.LookupVariable("a").Type.SpecialType.Should().Be(SpecialType.ClrInt32);
             boundBlockStatement.Scope.LookupVariable("b").Type.SpecialType.Should().Be(SpecialType.ClrInt32);
         }
@@ -68,7 +68,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var boundBlockStatement = TestUtils.BindStatement<BoundBlockStatement>(input);
 
             boundBlockStatement.Should().NotBeNull();
-            boundBlockStatement.Statements.Count.Should().Be(4);
+            boundBlockStatement.Statements.Should().HaveCount(4);
 
             var scope = boundBlockStatement.Scope;
             var childScope = (boundBlockStatement.Statements[2] as BoundBlockStatement).Scope;
@@ -102,7 +102,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var exceptionType = TestDefaults.DefaultClrTypeCache.Resolve(typeof(Exception).FullName);
             boundObjectCreationExpression.ResultType.Should().Be(exceptionType);
             boundObjectCreationExpression.ConstructorInfo.Should().NotBeNull();
-            boundObjectCreationExpression.BoundArguments.Count.Should().Be(1);
+            boundObjectCreationExpression.BoundArguments.Should().HaveCount(1);
 
             var message = boundObjectCreationExpression.BoundArguments[0].As<BoundConstant>();
             message.Value.Should().Be("exception message");

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionCallExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionCallExpressionTests.cs
@@ -26,7 +26,7 @@ public sealed class BoundFunctionCallExpressionTests
         boundFunctionCallExpression.ResultType.SpecialType.Should().Be(SpecialType.ClrInt32);
         boundFunctionCallExpression.MethodInfo.Name.Should().Be("Abs");
         boundFunctionCallExpression.IsStatic.Should().Be(true);
-        boundFunctionCallExpression.BoundArguments.Count.Should().Be(1);
+        boundFunctionCallExpression.BoundArguments.Should().HaveCount(1);
 
         var argument = boundFunctionCallExpression.BoundArguments[0].As<BoundUnaryExpression>();
         argument.Operator.BoundUnaryOperatorKind.Should().Be(BoundUnaryOperatorKind.UnaryMinus | BoundUnaryOperatorKind.Int);
@@ -41,7 +41,7 @@ public sealed class BoundFunctionCallExpressionTests
         boundFunctionCallExpression.ResultType.SpecialType.Should().Be(SpecialType.ClrString);
         boundFunctionCallExpression.MethodInfo.Name.Should().Be("ToString");
         boundFunctionCallExpression.IsStatic.Should().Be(false);
-        boundFunctionCallExpression.BoundArguments.Count.Should().Be(1);
+        boundFunctionCallExpression.BoundArguments.Should().HaveCount(1);
 
         var argument = boundFunctionCallExpression.BoundArguments[0].As<BoundConstant>();
         argument.Value.Should().Be("G");
@@ -57,7 +57,7 @@ public sealed class BoundFunctionCallExpressionTests
         boundFunctionCallExpression.IsStatic.Should().Be(false);
 
         var boundArguments = boundFunctionCallExpression.BoundArguments;
-        boundArguments.Count.Should().Be(3);
+        boundArguments.Should().HaveCount(3);
         boundArguments[0].As<BoundConstant>().Value.Should().Be("ab");
         boundArguments[1].As<BoundConstant>().Value.Should().Be(1);
         boundArguments[2].As<BoundConstant>().Value.Should().Be(2);
@@ -75,7 +75,7 @@ public sealed class BoundFunctionCallExpressionTests
         boundFunctionCallExpression.IsStatic.Should().Be(false);
 
         var boundArguments = boundFunctionCallExpression.BoundArguments;
-        boundArguments.Count.Should().Be(2);
+        boundArguments.Should().HaveCount(2);
         boundArguments[0].As<BoundConstant>().Value.Should().Be(1);
         boundArguments[1].As<BoundConstant>().Value.Should().Be(2);
     }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionMemberTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionMemberTests.cs
@@ -21,7 +21,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
 
-            function.Body.Statements.Count.Should().Be(expectedStatementsCount);
+            function.Body.Statements.Should().HaveCount(expectedStatementsCount);
             function.ReturnType.Name.Should().Be(expectedReturnType.FullName);
             function.ReturnType.IsArray.Should().Be(expectedReturnType.IsArray);
             function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
@@ -33,7 +33,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var function = TestUtils.BindMember<BoundFunctionMember>(
                 inputText: "void Main() { const a = 30; System.Threading.Thread.Sleep(a); }");
 
-            function.Body.Statements.Count.Should().Be(3);
+            function.Body.Statements.Should().HaveCount(3);
 
             var a = function.Body.Statements[0].As<BoundVariableDeclarationStatement>().Variable;
             a.Name.Should().Be("a");
@@ -56,7 +56,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             a.Name.Should().Be("a");
             a.Type.SpecialType.Should().Be(SpecialType.ClrInt32);
 
-            function.Body.Statements.Count.Should().Be(2);
+            function.Body.Statements.Should().HaveCount(2);
             function.Body.Statements[0].As<BoundExpressionStatement>().Expression.As<BoundClrFunctionCallExpression>().Should().NotBeNull();
 
             function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
@@ -100,7 +100,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
 
             var targetType = TestDefaults.DefaultClrTypeCache.Resolve(expectedReturnType.FullName);
-            function.Body.Statements.Count.Should().Be(1);
+            function.Body.Statements.Should().HaveCount(1);
             function.ReturnType.Should().Be(targetType);
             function.GetDiagnostics().Should().BeEmpty();
 
@@ -121,7 +121,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var resolvedExpectedType = TestDefaults.DefaultClrTypeCache.Resolve(expectedReturnType.FullName);
             var resolvedActualType = TestDefaults.DefaultClrTypeCache.Resolve(actualReturnType.FullName);
 
-            function.Body.Statements.Count.Should().Be(1);
+            function.Body.Statements.Should().HaveCount(1);
             function.ReturnType.Should().Be(resolvedExpectedType);
             function.GetDiagnostics().Should().NotBeEmpty();
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundLoopStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundLoopStatementTests.cs
@@ -18,7 +18,7 @@ public sealed class BoundLoopStatementTests
         var boundLoopStatement = TestUtils.BindStatement<BoundLoopStatement>(inputText);
         boundLoopStatement.GetDiagnostics().Should().BeEmpty();
         boundLoopStatement.ConditionNegated.Should().Be(negated);
-        boundLoopStatement.Body.As<BoundBlockStatement>().Statements.Count.Should().Be(expectedBodyStatementsCount);
+        boundLoopStatement.Body.As<BoundBlockStatement>().Statements.Should().HaveCount(expectedBodyStatementsCount);
         boundLoopStatement.BoundLoopContext.Should().NotBeNull();
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundNodeVisitor.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundNodeVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
@@ -18,7 +19,7 @@ internal abstract partial class BoundNodeVisitor
             return new BoundEntryPointTypeDefinition()
             {
                 SyntaxNode = boundTodlTypeDefinition.SyntaxNode,
-                BoundMembers = boundMembers,
+                BoundMembers = boundMembers.ToImmutableArray(),
                 DiagnosticBuilder = boundTodlTypeDefinition.DiagnosticBuilder
             };
         }
@@ -175,7 +176,7 @@ internal abstract partial class BoundNodeVisitor
         }
 
         var hasChange = false;
-        var statements = new List<BoundStatement>();
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
 
         foreach (var boundStatement in boundBlockStatement.Statements)
         {
@@ -196,7 +197,7 @@ internal abstract partial class BoundNodeVisitor
         return BoundNodeFactory.CreateBoundBlockStatement(
             syntaxNode: boundBlockStatement.SyntaxNode,
             scope: boundBlockStatement.Scope,
-            statements: statements,
+            statements: statements.ToImmutable(),
             diagnosticBuilder: boundBlockStatement.DiagnosticBuilder);
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBlockStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBlockStatement.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Syntax;
 
@@ -8,7 +8,7 @@ namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 internal sealed class BoundBlockStatement : BoundStatement
 {
     public BoundScope Scope { get; internal init; }
-    public IReadOnlyList<BoundStatement> Statements { get; internal init; }
+    public ImmutableArray<BoundStatement> Statements { get; internal init; }
 
     public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitBoundBlockStatement(this);
 }
@@ -19,7 +19,7 @@ public partial class Binder
         => BoundNodeFactory.CreateBoundBlockStatement(
             syntaxNode: blockStatement,
             scope: Scope,
-            statements: blockStatement.InnerStatements.Select(statement => BindStatement(statement)).ToList());
+            statements: ImmutableArray.CreateRange(blockStatement.InnerStatements.Select(BindStatement)));
 
     private BoundBlockStatement BindBlockStatement(BlockStatement blockStatement)
         => CreateBlockStatementBinder().BindBlockStatementInScope(blockStatement);

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -14,7 +14,7 @@ internal sealed class BoundClrFunctionCallExpression : BoundExpression
 {
     public BoundExpression BoundBaseExpression { get; internal init; }
     public MethodInfo MethodInfo { get; internal init; }
-    public IReadOnlyList<BoundExpression> BoundArguments { get; internal init; }
+    public ImmutableArray<BoundExpression> BoundArguments { get; internal init; }
     public override TypeSymbol ResultType => BoundBaseExpression.SyntaxNode.SyntaxTree.ClrTypeCache.Resolve(MethodInfo.ReturnType);
     public bool IsStatic => MethodInfo.IsStatic;
 
@@ -86,13 +86,16 @@ public partial class Binder
             ReportNoMatchingFunctionCandidate(diagnosticBuilder, functionCallExpression);
         }
 
-        var boundArguments = candidate?.GetParameters().OrderBy(p => p.Position).Select(p => arguments[p.Name]);
+        var boundArguments = candidate
+            .GetParameters()
+            .OrderBy(p => p.Position)
+            .Select(p => arguments[p.Name]);
 
         return BoundNodeFactory.CreateBoundClrFunctionCallExpression(
             syntaxNode: functionCallExpression,
             boundBaseExpression: boundBaseExpression,
             methodInfo: candidate,
-            boundArguments: boundArguments.ToList(),
+            boundArguments: boundArguments.ToImmutableArray(),
             diagnosticBuilder: diagnosticBuilder);
     }
 
@@ -123,7 +126,7 @@ public partial class Binder
             syntaxNode: functionCallExpression,
             boundBaseExpression: boundBaseExpression,
             methodInfo: candidate,
-            boundArguments: boundArguments.ToList(),
+            boundArguments: boundArguments.ToImmutableArray(),
             diagnosticBuilder: diagnosticBuilder);
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
@@ -88,7 +89,7 @@ public partial class Binder
         return new()
         {
             SyntaxNode = null,
-            BoundMembers = boundMembers.ToList(),
+            BoundMembers = boundMembers.ToImmutableArray(),
             DiagnosticBuilder = diagnosticBuilder
         };
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Immutable;
+using System.Linq;
 using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.Diagnostics;
@@ -60,7 +61,7 @@ public partial class Binder
                 body = BoundNodeFactory.CreateBoundBlockStatement(
                     syntaxNode: body.SyntaxNode,
                     scope: body.Scope,
-                    statements: body.Statements.Append(returnStatement).ToList());
+                    statements: body.Statements.Append(returnStatement).ToImmutableArray());
             }
         }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -13,7 +13,7 @@ namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 internal sealed class BoundObjectCreationExpression : BoundExpression
 {
     public ConstructorInfo ConstructorInfo { get; internal init; }
-    public IReadOnlyList<BoundExpression> BoundArguments { get; internal init; }
+    public ImmutableArray<BoundExpression> BoundArguments { get; internal init; }
     public override TypeSymbol ResultType
         => SyntaxNode.SyntaxTree.ClrTypeCache.Resolve(ConstructorInfo.DeclaringType);
 
@@ -29,7 +29,7 @@ public partial class Binder
         diagnosticBuilder.Add(boundTypeExpression);
 
         // Treating no arguments as the same way of positional arguments
-        if (!newExpression.Arguments.Items.Any() || !newExpression.Arguments.Items[0].IsNamedArgument)
+        if (newExpression.Arguments.Items.IsEmpty || !newExpression.Arguments.Items[0].IsNamedArgument)
         {
             return BindNewExpressionWithPositionalArgumentsInternal(
                 diagnosticBuilder: diagnosticBuilder,
@@ -67,7 +67,7 @@ public partial class Binder
         {
             SyntaxNode = newExpression,
             ConstructorInfo = constructorInfo,
-            BoundArguments = boundArguments.ToList(),
+            BoundArguments = boundArguments.ToImmutableArray(),
             DiagnosticBuilder = diagnosticBuilder
         };
     }
@@ -112,7 +112,7 @@ public partial class Binder
         {
             SyntaxNode = newExpression,
             ConstructorInfo = constructorInfo,
-            BoundArguments = boundArguments.ToList(),
+            BoundArguments = boundArguments.ToImmutableArray(),
             DiagnosticBuilder = diagnosticBuilder
         };
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlTypeDefinition.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlTypeDefinition.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
 internal abstract class BoundTodlTypeDefinition : BoundNode
 {
     public string Name { get; internal init; }
-    public IReadOnlyList<BoundMember> BoundMembers { get; internal init; }
+    public ImmutableArray<BoundMember> BoundMembers { get; internal init; }
     public virtual bool IsStatic => false;
     public virtual bool IsGeneratedType => false;
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeWalker.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeWalker.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
@@ -125,7 +125,7 @@ internal abstract class BoundTreeWalker : BoundTreeVisitor
 
     public override BoundNode VisitBoundTodlFunctionCallExpression(BoundTodlFunctionCallExpression boundTodlFunctionCallExpression)
     {
-        VisitList(boundTodlFunctionCallExpression.BoundArguments.Values);
+        VisitList(boundTodlFunctionCallExpression.BoundArguments);
 
         return boundTodlFunctionCallExpression;
     }
@@ -157,14 +157,27 @@ internal abstract class BoundTreeWalker : BoundTreeVisitor
         return boundVariableMember;
     }
 
-    private void VisitList<TBoundNode>(IEnumerable<TBoundNode> list) where TBoundNode : BoundNode
+    private void VisitList<TBoundNode>(ImmutableArray<TBoundNode> list) where TBoundNode : BoundNode
     {
-        if (list is null)
+        if (list.IsEmpty)
         {
             return;
         }
 
         foreach (var node in list)
+        {
+            Visit(node);
+        }
+    }
+
+    private void VisitList<TKey, TBoundNode>(ImmutableDictionary<TKey, TBoundNode> list) where TBoundNode : BoundNode
+    {
+        if (list is null || list.IsEmpty)
+        {
+            return;
+        }
+
+        foreach (var node in list.Values)
         {
             Visit(node);
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowGraph.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowGraph.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
@@ -10,8 +10,8 @@ internal sealed class ControlFlowGraph
 {
     public BasicBlock StartBlock => Blocks.First();
     public BasicBlock EndBlock => Blocks.Last();
-    public IReadOnlyCollection<BasicBlock> Blocks { get; private init; }
-    public IReadOnlyCollection<BasicBlockBranch> Branches { get; private init; }
+    public ImmutableArray<BasicBlock> Blocks { get; private init; }
+    public ImmutableArray<BasicBlockBranch> Branches { get; private init; }
 
     internal static ControlFlowGraph Create(BoundFunctionMember boundFunctionMember)
     {
@@ -23,8 +23,8 @@ internal sealed class ControlFlowGraph
 
     private sealed class Builder : BoundTreeWalker
     {
-        private readonly List<BasicBlock> blocks = new();
-        private readonly List<BasicBlockBranch> branches = new();
+        private readonly ImmutableArray<BasicBlock>.Builder blocks = ImmutableArray.CreateBuilder<BasicBlock>();
+        private readonly ImmutableArray<BasicBlockBranch>.Builder branches = ImmutableArray.CreateBuilder<BasicBlockBranch>();
         private readonly BasicBlock startBlock = new();
         private readonly BasicBlock endBlock = new();
 
@@ -53,7 +53,7 @@ internal sealed class ControlFlowGraph
 
         public override BoundNode VisitBoundBlockStatement(BoundBlockStatement boundBlockStatement)
         {
-            if (!boundBlockStatement.Statements.Any())
+            if (boundBlockStatement.Statements.IsEmpty)
             {
                 current.Statements.Add(new BoundNoOpStatement());
                 return boundBlockStatement;
@@ -192,8 +192,8 @@ internal sealed class ControlFlowGraph
 
             return new()
             {
-                Blocks = blocks,
-                Branches = branches
+                Blocks = blocks.ToImmutable(),
+                Branches = branches.ToImmutable()
             };
         }
     }


### PR DESCRIPTION
Following the previous PR, this one converts `BoundNode` classes to utilize immutable collections.