### PR TITLE
Remove DiagnosticBag from BoundNode

### DIFF
--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundAssignmentExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundAssignmentExpressionTests.cs
@@ -27,7 +27,6 @@ public sealed class BoundAssignmentExpressionTests
         var block = TestUtils.BindStatement<BoundBlockStatement>(input);
         var boundAssignmentExpression = block.Statements[1].As<BoundExpressionStatement>().Expression.As<BoundAssignmentExpression>();
         boundAssignmentExpression.Should().NotBeNull();
-        boundAssignmentExpression.GetDiagnostics().Should().BeEmpty();
 
         boundAssignmentExpression.Operator.BoundAssignmentOperatorKind.Should().Be(expectedBoundAssignmentOperatorKind);
         boundAssignmentExpression.ResultType.SpecialType.Should().Be(expectedResultType);
@@ -47,11 +46,12 @@ public sealed class BoundAssignmentExpressionTests
     [InlineData("{ const n = 0; n /= 10; }")]
     public void TestBindAssignmentExpressionWithReadonlyVariables(string input)
     {
-        var block = TestUtils.BindStatement<BoundBlockStatement>(input);
+        var diagnosticsBuilder = new DiagnosticBag.Builder();
+        var block = TestUtils.BindStatement<BoundBlockStatement>(input, diagnosticsBuilder);
         var boundAssignmentExpression = block.Statements[1].As<BoundExpressionStatement>().Expression.As<BoundAssignmentExpression>();
         boundAssignmentExpression.Should().NotBeNull();
 
-        var diagnostics = boundAssignmentExpression.GetDiagnostics();
+        var diagnostics = diagnosticsBuilder.Build();
         diagnostics.Should().HaveCount(1);
 
         var readonlyVariable = diagnostics.First();
@@ -68,10 +68,11 @@ public sealed class BoundAssignmentExpressionTests
     [InlineData("n /= 10;")]
     public void TestBindAssignmentExpressionWithUndeclaredVariables(string input)
     {
-        var boundAssignmentExpression = TestUtils.BindExpression<BoundAssignmentExpression>(input);
+        var diagnosticsBuilder = new DiagnosticBag.Builder();
+        var boundAssignmentExpression = TestUtils.BindExpression<BoundAssignmentExpression>(input, diagnosticsBuilder);
         boundAssignmentExpression.Should().NotBeNull();
 
-        var diagnostics = boundAssignmentExpression.GetDiagnostics();
+        var diagnostics = diagnosticsBuilder.Build();
         diagnostics.Should().HaveCount(1);
 
         var undeclaredVariable = diagnostics.First();
@@ -88,11 +89,12 @@ public sealed class BoundAssignmentExpressionTests
     [InlineData("{ let n = 0; n /= \"abc\"; }")]
     public void TestBindAssignmentExpressionWithMismatchedTypes(string input)
     {
-        var block = TestUtils.BindStatement<BoundBlockStatement>(input);
+        var diagnosticsBuilder = new DiagnosticBag.Builder();
+        var block = TestUtils.BindStatement<BoundBlockStatement>(input, diagnosticsBuilder);
         var boundAssignmentExpression = block.Statements[1].As<BoundExpressionStatement>().Expression.As<BoundAssignmentExpression>();
         boundAssignmentExpression.Should().NotBeNull();
 
-        var diagnostics = boundAssignmentExpression.GetDiagnostics();
+        var diagnostics = diagnosticsBuilder.Build();
         diagnostics.Should().HaveCount(1);
 
         var typeMismatch = diagnostics.First();

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundConditionalStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundConditionalStatementTests.cs
@@ -16,7 +16,6 @@ public sealed class BoundConditionalStatementTests
     {
         var boundConditionalStatement = TestUtils.BindStatement<BoundConditionalStatement>(inputText);
         boundConditionalStatement.Should().NotBeNull();
-        boundConditionalStatement.GetDiagnostics().Should().BeEmpty();
 
         boundConditionalStatement.Condition.As<BoundConstant>().Value.Should().Be(true);
 
@@ -30,7 +29,6 @@ public sealed class BoundConditionalStatementTests
         var inputText = "if true { 0.ToString(); } else { 1.ToString(); }";
         var boundConditionalStatement = TestUtils.BindStatement<BoundConditionalStatement>(inputText);
         boundConditionalStatement.Should().NotBeNull();
-        boundConditionalStatement.GetDiagnostics().Should().BeEmpty();
 
         boundConditionalStatement.Condition.As<BoundConstant>().Value.Should().Be(true);
 
@@ -47,7 +45,6 @@ public sealed class BoundConditionalStatementTests
         var inputText = "unless 0 == 1 { 0.ToString(); } else unless 1 == 2 { 1.ToString(); } else { 2.ToString(); }";
         var boundConditionalStatement = TestUtils.BindStatement<BoundConditionalStatement>(inputText);
         boundConditionalStatement.Should().NotBeNull();
-        boundConditionalStatement.GetDiagnostics().Should().BeEmpty();
 
         void ValidateCondition(BoundConditionalStatement boundConditionalStatement, int expectedLeft, int expectedRight)
         {
@@ -96,11 +93,11 @@ public sealed class BoundConditionalStatementTests
     [InlineData("if 0 { 0.ToString(); }")]
     public void BoundConditionalStatementShouldHaveBooleanConditions(string inputText)
     {
-        var boundConditionalStatement = TestUtils.BindStatement<BoundConditionalStatement>(inputText);
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var boundConditionalStatement = TestUtils.BindStatement<BoundConditionalStatement>(inputText, diagnosticBuilder);
         boundConditionalStatement.Should().NotBeNull();
 
-        var diagnostics = boundConditionalStatement.GetDiagnostics().ToList();
-        diagnostics[0].ErrorCode.Should().Be(ErrorCode.TypeMismatch);
+        diagnosticBuilder.Build().First().ErrorCode.Should().Be(ErrorCode.TypeMismatch);
     }
 
     [Fact]

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionMemberTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionMemberTests.cs
@@ -7,224 +7,221 @@ using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.Diagnostics;
 using Xunit;
 
-namespace Todl.Compiler.Tests.CodeAnalysis
+namespace Todl.Compiler.Tests.CodeAnalysis;
+
+public sealed class BoundFunctionMemberTests
 {
-    public sealed class BoundFunctionMemberTests
+    [Theory]
+    [InlineData("int Function() {}", typeof(int), 0)]
+    [InlineData("System.Uri Function() {}", typeof(Uri), 0)]
+    [InlineData("void Function() {}", typeof(void), 1)]
+    [InlineData("int[] Function() {}", typeof(int[]), 0)]
+    [InlineData("System.Uri[][] Function() {}", typeof(Uri[][]), 0)]
+    public void TestBindFunctionDeclarationMemberWithoutParametersOrBody(string inputText, Type expectedReturnType, int expectedStatementsCount)
     {
-        [Theory]
-        [InlineData("int Function() {}", typeof(int), 0)]
-        [InlineData("System.Uri Function() {}", typeof(Uri), 0)]
-        [InlineData("void Function() {}", typeof(void), 1)]
-        [InlineData("int[] Function() {}", typeof(int[]), 0)]
-        [InlineData("System.Uri[][] Function() {}", typeof(Uri[][]), 0)]
-        public void TestBindFunctionDeclarationMemberWithoutParametersOrBody(string inputText, Type expectedReturnType, int expectedStatementsCount)
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
+        var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
 
-            function.Body.Statements.Should().HaveCount(expectedStatementsCount);
-            function.ReturnType.Name.Should().Be(expectedReturnType.FullName);
-            function.ReturnType.IsArray.Should().Be(expectedReturnType.IsArray);
-            function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
-        }
+        function.Body.Statements.Should().HaveCount(expectedStatementsCount);
+        function.ReturnType.Name.Should().Be(expectedReturnType.FullName);
+        function.ReturnType.IsArray.Should().Be(expectedReturnType.IsArray);
+        function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
+    }
 
-        [Fact]
-        public void TestBindFunctionDeclarationMemberWithBody()
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(
-                inputText: "void Main() { const a = 30; System.Threading.Thread.Sleep(a); }");
+    [Fact]
+    public void TestBindFunctionDeclarationMemberWithBody()
+    {
+        var function = TestUtils.BindMember<BoundFunctionMember>(
+            inputText: "void Main() { const a = 30; System.Threading.Thread.Sleep(a); }");
 
-            function.Body.Statements.Should().HaveCount(3);
+        function.Body.Statements.Should().HaveCount(3);
 
-            var a = function.Body.Statements[0].As<BoundVariableDeclarationStatement>().Variable;
-            a.Name.Should().Be("a");
-            function.FunctionScope.LookupVariable("a").Should().Be(a);
+        var a = function.Body.Statements[0].As<BoundVariableDeclarationStatement>().Variable;
+        a.Name.Should().Be("a");
+        function.FunctionScope.LookupVariable("a").Should().Be(a);
 
-            function.Body.Statements[1].As<BoundExpressionStatement>().Expression.As<BoundClrFunctionCallExpression>().Should().NotBeNull();
+        function.Body.Statements[1].As<BoundExpressionStatement>().Expression.As<BoundClrFunctionCallExpression>().Should().NotBeNull();
 
-            function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
-            function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
-        }
+        function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
+        function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
+    }
 
-        [Fact]
-        public void TestBindFunctionDeclarationMemberWithParameters()
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(
-                inputText: "void Sleep(int a) { System.Threading.Thread.Sleep(a); }");
+    [Fact]
+    public void TestBindFunctionDeclarationMemberWithParameters()
+    {
+        var function = TestUtils.BindMember<BoundFunctionMember>(
+            inputText: "void Sleep(int a) { System.Threading.Thread.Sleep(a); }");
 
-            var a = function.FunctionScope.LookupVariable("a");
-            a.Should().NotBeNull();
-            a.Name.Should().Be("a");
-            a.Type.SpecialType.Should().Be(SpecialType.ClrInt32);
+        var a = function.FunctionScope.LookupVariable("a");
+        a.Should().NotBeNull();
+        a.Name.Should().Be("a");
+        a.Type.SpecialType.Should().Be(SpecialType.ClrInt32);
 
-            function.Body.Statements.Should().HaveCount(2);
-            function.Body.Statements[0].As<BoundExpressionStatement>().Expression.As<BoundClrFunctionCallExpression>().Should().NotBeNull();
+        function.Body.Statements.Should().HaveCount(2);
+        function.Body.Statements[0].As<BoundExpressionStatement>().Expression.As<BoundClrFunctionCallExpression>().Should().NotBeNull();
 
-            function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
-            function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
-        }
+        function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
+        function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
+    }
 
-        [Fact]
-        public void TestBindFunctionDeclarationMemberWithArrayParameters()
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(
-                inputText: "void Function(int a, int[] b, string[][] c) { }");
+    [Fact]
+    public void TestBindFunctionDeclarationMemberWithArrayParameters()
+    {
+        var function = TestUtils.BindMember<BoundFunctionMember>(
+            inputText: "void Function(int a, int[] b, string[][] c) { }");
 
-            var a = function.FunctionScope.LookupVariable("a");
-            a.Should().NotBeNull();
-            a.Name.Should().Be("a");
-            a.Type.SpecialType.Should().Be(SpecialType.ClrInt32);
-            a.Type.IsArray.Should().BeFalse();
+        var a = function.FunctionScope.LookupVariable("a");
+        a.Should().NotBeNull();
+        a.Name.Should().Be("a");
+        a.Type.SpecialType.Should().Be(SpecialType.ClrInt32);
+        a.Type.IsArray.Should().BeFalse();
 
-            var b = function.FunctionScope.LookupVariable("b");
-            b.Should().NotBeNull();
-            b.Name.Should().Be("b");
-            b.Type.As<ClrTypeSymbol>().ClrType.GetElementType().Should().Be(TestDefaults.DefaultClrTypeCache.BuiltInTypes.Int32.ClrType);
-            b.Type.IsArray.Should().BeTrue();
+        var b = function.FunctionScope.LookupVariable("b");
+        b.Should().NotBeNull();
+        b.Name.Should().Be("b");
+        b.Type.As<ClrTypeSymbol>().ClrType.GetElementType().Should().Be(TestDefaults.DefaultClrTypeCache.BuiltInTypes.Int32.ClrType);
+        b.Type.IsArray.Should().BeTrue();
 
-            var c = function.FunctionScope.LookupVariable("c");
-            c.Should().NotBeNull();
-            c.Name.Should().Be("c");
-            c.Type.As<ClrTypeSymbol>().ClrType.GetElementType().GetElementType().Should().Be(TestDefaults.DefaultClrTypeCache.BuiltInTypes.String.ClrType);
-            c.Type.IsArray.Should().BeTrue();
+        var c = function.FunctionScope.LookupVariable("c");
+        c.Should().NotBeNull();
+        c.Name.Should().Be("c");
+        c.Type.As<ClrTypeSymbol>().ClrType.GetElementType().GetElementType().Should().Be(TestDefaults.DefaultClrTypeCache.BuiltInTypes.String.ClrType);
+        c.Type.IsArray.Should().BeTrue();
 
-            function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
-            function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
-        }
+        function.ReturnType.SpecialType.Should().Be(SpecialType.ClrVoid);
+        function.FunctionScope.BoundScopeKind.Should().Be(BoundScopeKind.Function);
+    }
 
-        [Theory]
-        [InlineData("int Function() { return 0; }", typeof(int))]
-        [InlineData("System.Uri Function() { return new System.Uri(\"https://www.google.com\"); }", typeof(Uri))]
-        [InlineData("void Function() { return; }", typeof(void))]
-        public void TestBindFunctionDeclarationMemberWithReturnStatement(string inputText, Type expectedReturnType)
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
+    [Theory]
+    [InlineData("int Function() { return 0; }", typeof(int))]
+    [InlineData("System.Uri Function() { return new System.Uri(\"https://www.google.com\"); }", typeof(Uri))]
+    [InlineData("void Function() { return; }", typeof(void))]
+    public void TestBindFunctionDeclarationMemberWithReturnStatement(string inputText, Type expectedReturnType)
+    {
+        var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
 
-            var targetType = TestDefaults.DefaultClrTypeCache.Resolve(expectedReturnType.FullName);
-            function.Body.Statements.Should().HaveCount(1);
-            function.ReturnType.Should().Be(targetType);
-            function.GetDiagnostics().Should().BeEmpty();
+        var targetType = TestDefaults.DefaultClrTypeCache.Resolve(expectedReturnType.FullName);
+        function.Body.Statements.Should().HaveCount(1);
+        function.ReturnType.Should().Be(targetType);
 
-            var returnStatement = function.Body.Statements[0].As<BoundReturnStatement>();
-            returnStatement.Should().NotBeNull();
-            returnStatement.GetDiagnostics().Should().BeEmpty();
-            returnStatement.ReturnType.Should().Be(targetType);
-        }
+        var returnStatement = function.Body.Statements[0].As<BoundReturnStatement>();
+        returnStatement.Should().NotBeNull();
+        returnStatement.ReturnType.Should().Be(targetType);
+    }
 
-        [Theory]
-        [InlineData("int Function() { return; }", typeof(int), typeof(void))]
-        [InlineData("System.Uri Function() { return \"https://www.google.com\"; }", typeof(Uri), typeof(string))]
-        [InlineData("void Function() { return 0; }", typeof(void), typeof(int))]
-        public void TestBindFunctionDeclarationMemberWithMismatchedReturnStatement(string inputText, Type expectedReturnType, Type actualReturnType)
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
+    [Theory]
+    [InlineData("int Function() { return; }", typeof(int), typeof(void))]
+    [InlineData("System.Uri Function() { return \"https://www.google.com\"; }", typeof(Uri), typeof(string))]
+    [InlineData("void Function() { return 0; }", typeof(void), typeof(int))]
+    public void TestBindFunctionDeclarationMemberWithMismatchedReturnStatement(string inputText, Type expectedReturnType, Type actualReturnType)
+    {
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var function = TestUtils.BindMember<BoundFunctionMember>(inputText, diagnosticBuilder);
 
-            var resolvedExpectedType = TestDefaults.DefaultClrTypeCache.Resolve(expectedReturnType.FullName);
-            var resolvedActualType = TestDefaults.DefaultClrTypeCache.Resolve(actualReturnType.FullName);
+        var resolvedExpectedType = TestDefaults.DefaultClrTypeCache.Resolve(expectedReturnType.FullName);
+        var resolvedActualType = TestDefaults.DefaultClrTypeCache.Resolve(actualReturnType.FullName);
 
-            function.Body.Statements.Should().HaveCount(1);
-            function.ReturnType.Should().Be(resolvedExpectedType);
-            function.GetDiagnostics().Should().NotBeEmpty();
+        function.Body.Statements.Should().HaveCount(1);
+        function.ReturnType.Should().Be(resolvedExpectedType);
 
-            var returnStatement = function.Body.Statements[0].As<BoundReturnStatement>();
-            returnStatement.Should().NotBeNull();
-            returnStatement.GetDiagnostics().Should().NotBeEmpty();
-            returnStatement.ReturnType.Should().Be(resolvedActualType);
+        var returnStatement = function.Body.Statements[0].As<BoundReturnStatement>();
+        returnStatement.Should().NotBeNull();
+        returnStatement.ReturnType.Should().Be(resolvedActualType);
 
-            var diagnostics = function.GetDiagnostics().ToList();
-            diagnostics.Count.Should().Be(1);
-            diagnostics[0].ErrorCode.Should().Be(ErrorCode.TypeMismatch);
-            diagnostics[0].Message.Should().Be($"The function expects a return type of {expectedReturnType} but {actualReturnType} is returned.");
-        }
+        var diagnostics = diagnosticBuilder.Build().ToList();
+        diagnostics.Count.Should().Be(1);
+        diagnostics[0].ErrorCode.Should().Be(ErrorCode.TypeMismatch);
+        diagnostics[0].Message.Should().Be($"The function expects a return type of {expectedReturnType} but {actualReturnType} is returned.");
+    }
 
-        [Fact]
-        public void TestOverloadedFunctionDeclarationMember()
-        {
-            var inputText = @"
-                int func() { return 20; }
-                int func(int a) { return a; }
-            ";
-            var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-            var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
+    [Fact]
+    public void TestOverloadedFunctionDeclarationMember()
+    {
+        var inputText = @"
+            int func() { return 20; }
+            int func(int a) { return a; }
+        ";
+        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
+        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-            boundModule.GetDiagnostics().Should().BeEmpty();
-        }
+        boundModule.GetDiagnostics().Should().BeEmpty();
+    }
 
-        [Theory]
-        [InlineData("void func(int a, int a) { }")]
-        [InlineData("void func(int a, string a) { }")]
-        public void FunctionParametersShouldHaveDistinctNames(string inputText)
-        {
-            var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-            var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
+    [Theory]
+    [InlineData("void func(int a, int a) { }")]
+    [InlineData("void func(int a, string a) { }")]
+    public void FunctionParametersShouldHaveDistinctNames(string inputText)
+    {
+        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
+        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-            var diagnostics = boundModule.GetDiagnostics().ToList();
-            diagnostics.Should().NotBeEmpty();
-            diagnostics[0].ErrorCode.Should().Be(ErrorCode.DuplicateParameterName);
-        }
+        var diagnostics = boundModule.GetDiagnostics().ToList();
+        diagnostics.Should().NotBeEmpty();
+        diagnostics[0].ErrorCode.Should().Be(ErrorCode.DuplicateParameterName);
+    }
 
-        [Fact]
-        public void FunctionsWithSameArgumentsShouldBeAmbiguous()
-        {
-            var inputText = @"
-                int func(int a, string b) { return b.Length + a; }
-                int func(int a, string b) { return b.Length + a + 1; }
-            ";
-            var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-            var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
+    [Fact]
+    public void FunctionsWithSameArgumentsShouldBeAmbiguous()
+    {
+        var inputText = @"
+            int func(int a, string b) { return b.Length + a; }
+            int func(int a, string b) { return b.Length + a + 1; }
+        ";
+        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
+        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-            var diagnostics = boundModule.GetDiagnostics().ToList();
-            diagnostics.Count.Should().Be(1);
-            diagnostics[0].ErrorCode.Should().Be(ErrorCode.AmbiguousFunctionDeclaration);
-        }
+        var diagnostics = boundModule.GetDiagnostics().ToList();
+        diagnostics.Count.Should().Be(1);
+        diagnostics[0].ErrorCode.Should().Be(ErrorCode.AmbiguousFunctionDeclaration);
+    }
 
-        [Fact]
-        public void FunctionsWithSameArgumentsInDifferentOrderShouldBeAmbiguous()
-        {
-            // the following function declarations are ambiguous
-            // considering a function call expression like this: func(a: 10, b: "abc")
-            // in C# this is permitted since it's ok if you stick with positional arguments
-            // but in todl I would like to avoid potential ambiguity from function declaration
-            var inputText = @"
-                int func(int a, string b) { return b.Length + a; }
-                int func(string b, int a) { return b.Length + a + 1; }
-            ";
-            var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-            var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
+    [Fact]
+    public void FunctionsWithSameArgumentsInDifferentOrderShouldBeAmbiguous()
+    {
+        // the following function declarations are ambiguous
+        // considering a function call expression like this: func(a: 10, b: "abc")
+        // in C# this is permitted since it's ok if you stick with positional arguments
+        // but in todl I would like to avoid potential ambiguity from function declaration
+        var inputText = @"
+            int func(int a, string b) { return b.Length + a; }
+            int func(string b, int a) { return b.Length + a + 1; }
+        ";
+        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
+        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-            var diagnostics = boundModule.GetDiagnostics().ToList();
-            diagnostics.Count.Should().Be(1);
-            diagnostics[0].ErrorCode.Should().Be(ErrorCode.AmbiguousFunctionDeclaration);
-        }
+        var diagnostics = boundModule.GetDiagnostics().ToList();
+        diagnostics.Count.Should().Be(1);
+        diagnostics[0].ErrorCode.Should().Be(ErrorCode.AmbiguousFunctionDeclaration);
+    }
 
-        [Fact]
-        public void FunctionsWithSameArgumentsButDifferentNamesShouldBeAmbiguous()
-        {
-            var inputText = @"
-                int func(int a, string b) { return b.Length + a; }
-                int func(int b, string a) { return a.Length + b + 1; }
-            ";
-            var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-            var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
+    [Fact]
+    public void FunctionsWithSameArgumentsButDifferentNamesShouldBeAmbiguous()
+    {
+        var inputText = @"
+            int func(int a, string b) { return b.Length + a; }
+            int func(int b, string a) { return a.Length + b + 1; }
+        ";
+        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
+        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-            var diagnostics = boundModule.GetDiagnostics().ToList();
-            diagnostics.Count.Should().Be(1);
-            diagnostics[0].ErrorCode.Should().Be(ErrorCode.AmbiguousFunctionDeclaration);
-        }
+        var diagnostics = boundModule.GetDiagnostics().ToList();
+        diagnostics.Count.Should().Be(1);
+        diagnostics[0].ErrorCode.Should().Be(ErrorCode.AmbiguousFunctionDeclaration);
+    }
 
-        [Theory]
-        [InlineData("void func() {}")]
-        [InlineData("void func() { return; }")]
-        [InlineData("void func(int a) { System.Threading.Thread.Sleep(a); }")]
-        [InlineData("void func(int a) { System.Threading.Thread.Sleep(a); return; }")]
-        public void FunctionsThatReturnsVoidShouldNotHaveDuplicateReturnStatements(string inputText)
-        {
-            var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
-            function.Body.Statements.Should().NotBeEmpty();
+    [Theory]
+    [InlineData("void func() {}")]
+    [InlineData("void func() { return; }")]
+    [InlineData("void func(int a) { System.Threading.Thread.Sleep(a); }")]
+    [InlineData("void func(int a) { System.Threading.Thread.Sleep(a); return; }")]
+    public void FunctionsThatReturnsVoidShouldNotHaveDuplicateReturnStatements(string inputText)
+    {
+        var function = TestUtils.BindMember<BoundFunctionMember>(inputText);
+        function.Body.Statements.Should().NotBeEmpty();
 
-            function.Body.Statements.OfType<BoundReturnStatement>().Should().HaveCount(1);
+        function.Body.Statements.OfType<BoundReturnStatement>().Should().HaveCount(1);
 
-            var lastStatement = function.Body.Statements[^1];
-            lastStatement.Should().BeOfType<BoundReturnStatement>();
-        }
+        var lastStatement = function.Body.Statements[^1];
+        lastStatement.Should().BeOfType<BoundReturnStatement>();
     }
 }
+

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundMemberAccessExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundMemberAccessExpressionTests.cs
@@ -14,7 +14,6 @@ public sealed class BoundMemberAccessExpressionTests
     {
         var boundClrPropertyAccessExpression = TestUtils.BindExpression<BoundClrPropertyAccessExpression>("\"abc\".Length");
 
-        boundClrPropertyAccessExpression.GetDiagnostics().Should().BeEmpty();
         boundClrPropertyAccessExpression.MemberName.Should().Be("Length");
         boundClrPropertyAccessExpression.ResultType.SpecialType.Should().Be(SpecialType.ClrInt32);
         boundClrPropertyAccessExpression.IsStatic.Should().Be(false);
@@ -27,7 +26,6 @@ public sealed class BoundMemberAccessExpressionTests
     {
         var boundClrFieldAccessExpression = TestUtils.BindExpression<BoundClrFieldAccessExpression>("System.Int32.MaxValue");
 
-        boundClrFieldAccessExpression.GetDiagnostics().Should().BeEmpty();
         boundClrFieldAccessExpression.MemberName.Should().Be("MaxValue");
         boundClrFieldAccessExpression.ResultType.SpecialType.Should().Be(SpecialType.ClrInt32);
         boundClrFieldAccessExpression.IsStatic.Should().Be(true);
@@ -38,9 +36,10 @@ public sealed class BoundMemberAccessExpressionTests
     [Fact]
     public void TestBoundInvalidMemberAccessExpression()
     {
-        var boundExpression = TestUtils.BindExpression<BoundMemberAccessExpression>("System.Int32.Maxvalue");
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var boundExpression = TestUtils.BindExpression<BoundMemberAccessExpression>("System.Int32.Maxvalue", diagnosticBuilder);
 
-        var diagnostic = boundExpression.GetDiagnostics().First();
+        var diagnostic = diagnosticBuilder.Build().First();
         diagnostic.Level.Should().Be(DiagnosticLevel.Error);
         diagnostic.Message.Should().Be("Member 'Maxvalue' does not exist in type 'System.Int32'");
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundNodeVisitor.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundNodeVisitor.cs
@@ -13,14 +13,12 @@ internal abstract partial class BoundNodeVisitor
         if (boundTodlTypeDefinition is BoundEntryPointTypeDefinition)
         {
             var boundMembers = VisitBoundMembers(boundTodlTypeDefinition.BoundMembers).ToList();
-            boundTodlTypeDefinition.DiagnosticBuilder.AddRange(boundMembers);
 
             // TODO: Use BoundNodeFactory to initialize BoundEntryPointTypeDefinition
             return new BoundEntryPointTypeDefinition()
             {
                 SyntaxNode = boundTodlTypeDefinition.SyntaxNode,
-                BoundMembers = boundMembers.ToImmutableArray(),
-                DiagnosticBuilder = boundTodlTypeDefinition.DiagnosticBuilder
+                BoundMembers = boundMembers.ToImmutableArray()
             };
         }
 
@@ -80,8 +78,7 @@ internal abstract partial class BoundNodeVisitor
             syntaxNode: boundAssignmentExpression.SyntaxNode,
             left: newLeft,
             @operator: boundAssignmentExpression.Operator,
-            right: newRight,
-            diagnosticBuilder: boundAssignmentExpression.DiagnosticBuilder);
+            right: newRight);
     }
 
     protected virtual BoundExpression VisitBoundBinaryExpression(BoundBinaryExpression boundBinaryExpression)
@@ -98,8 +95,7 @@ internal abstract partial class BoundNodeVisitor
             syntaxNode: boundBinaryExpression.SyntaxNode,
             @operator: boundBinaryExpression.Operator,
             left: newLeft,
-            right: newRight,
-            diagnosticBuilder: boundBinaryExpression.DiagnosticBuilder);
+            right: newRight);
     }
 
     protected virtual BoundExpression VisitBoundConstant(BoundConstant boundConstant)
@@ -131,8 +127,7 @@ internal abstract partial class BoundNodeVisitor
         return BoundNodeFactory.CreateBoundUnaryExpression(
             syntaxNode: boundUnaryExpression.SyntaxNode,
             @operator: boundUnaryExpression.Operator,
-            operand: newOperand,
-            diagnosticBuilder: boundUnaryExpression.DiagnosticBuilder);
+            operand: newOperand);
     }
 
     protected virtual BoundExpression VisitBoundVariableExpression(BoundVariableExpression boundVariableExpression)
@@ -150,8 +145,7 @@ internal abstract partial class BoundNodeVisitor
             syntaxNode: boundFunctionMember.SyntaxNode,
             functionScope: boundFunctionMember.FunctionScope,
             body: (BoundBlockStatement)newBody,
-            functionSymbol: boundFunctionMember.FunctionSymbol,
-            diagnosticBuilder: boundFunctionMember.DiagnosticBuilder);
+            functionSymbol: boundFunctionMember.FunctionSymbol);
     }
 
     protected virtual BoundVariableMember VisitBoundVariableMember(BoundVariableMember boundVariableMember)
@@ -164,8 +158,7 @@ internal abstract partial class BoundNodeVisitor
 
         return BoundNodeFactory.CreateBoundVariableMember(
             syntaxNode: boundVariableMember.SyntaxNode,
-            boundVariableDeclarationStatement: (BoundVariableDeclarationStatement)newStatement,
-            diagnosticBuilder: boundVariableMember.DiagnosticBuilder);
+            boundVariableDeclarationStatement: (BoundVariableDeclarationStatement)newStatement);
     }
 
     protected virtual BoundStatement VisitBoundBlockStatement(BoundBlockStatement boundBlockStatement)
@@ -197,8 +190,7 @@ internal abstract partial class BoundNodeVisitor
         return BoundNodeFactory.CreateBoundBlockStatement(
             syntaxNode: boundBlockStatement.SyntaxNode,
             scope: boundBlockStatement.Scope,
-            statements: statements.ToImmutable(),
-            diagnosticBuilder: boundBlockStatement.DiagnosticBuilder);
+            statements: statements.ToImmutable());
     }
 
     protected virtual BoundStatement VisitBoundExpressionStatement(BoundExpressionStatement boundExpressionStatement)
@@ -211,8 +203,7 @@ internal abstract partial class BoundNodeVisitor
 
         return BoundNodeFactory.CreateBoundExpressionStatement(
             syntaxNode: boundExpressionStatement.SyntaxNode,
-            expression: newExpression,
-            diagnosticBuilder: boundExpressionStatement.DiagnosticBuilder);
+            expression: newExpression);
     }
 
     protected virtual BoundStatement VisitBoundReturnStatement(BoundReturnStatement boundReturnStatement)
@@ -230,8 +221,7 @@ internal abstract partial class BoundNodeVisitor
 
         return BoundNodeFactory.CreateBoundReturnStatement(
             syntaxNode: boundReturnStatement.SyntaxNode,
-            boundReturnValueExpression: newExpression,
-            diagnosticBuilder: boundReturnStatement.DiagnosticBuilder);
+            boundReturnValueExpression: newExpression);
     }
 
     protected virtual BoundStatement VisitBoundVariableDeclarationStatement(BoundVariableDeclarationStatement boundVariableDeclarationStatement)
@@ -255,8 +245,7 @@ internal abstract partial class BoundNodeVisitor
             syntaxNode: boundConditionalStatement.SyntaxNode,
             condition: condition,
             consequence: consequence,
-            alternative: alternative,
-            diagnosticBuilder: boundConditionalStatement.DiagnosticBuilder);
+            alternative: alternative);
     }
 
     protected virtual BoundStatement VisitBoundLoopStatement(BoundLoopStatement boundLoopStatement)
@@ -275,7 +264,6 @@ internal abstract partial class BoundNodeVisitor
             condition: condition,
             conditionNegated: boundLoopStatement.ConditionNegated,
             body: body,
-            boundLoopContext: boundLoopStatement.BoundLoopContext,
-            diagnosticBuilder: boundLoopStatement.DiagnosticBuilder);
+            boundLoopContext: boundLoopStatement.BoundLoopContext);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundAssignmentExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundAssignmentExpression.cs
@@ -53,7 +53,6 @@ public partial class Binder
 {
     private BoundAssignmentExpression BindAssignmentExpression(AssignmentExpression assignmentExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var boundAssignmentOperator = BoundAssignmentExpression.MatchAssignmentOperator(assignmentExpression.AssignmentOperator.Kind);
         var right = BindExpression(assignmentExpression.Right);
 
@@ -77,7 +76,7 @@ public partial class Binder
             }
             else if (variable.ReadOnly)
             {
-                diagnosticBuilder.Add(
+                ReportDiagnostic(
                     new Diagnostic()
                     {
                         Message = $"Variable {variableName} is read-only",
@@ -88,7 +87,7 @@ public partial class Binder
             }
             else if (!variable.Type.Equals(right.ResultType))
             {
-                diagnosticBuilder.Add(
+                ReportDiagnostic(
                     new Diagnostic()
                     {
                         Message = $"Variable {variableName} cannot be assigned to type {right.ResultType}",
@@ -102,7 +101,7 @@ public partial class Binder
         var left = BindExpression(assignmentExpression.Left);
         if (!left.LValue)
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = $"The left-hand side of an assignment must be a variable, property or indexer",
@@ -116,7 +115,6 @@ public partial class Binder
             syntaxNode: assignmentExpression,
             left: left,
             right: right,
-            @operator: boundAssignmentOperator,
-            diagnosticBuilder: diagnosticBuilder);
+            @operator: boundAssignmentOperator);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBinaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBinaryExpression.cs
@@ -89,14 +89,13 @@ public partial class Binder
 {
     private BoundBinaryExpression BindBinaryExpression(BinaryExpression binaryExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var boundLeft = BindExpression(binaryExpression.Left);
         var boundRight = BindExpression(binaryExpression.Right);
         var boundBinaryOperator = BoundBinaryOperatorFactory.MatchBinaryOperator(boundLeft.ResultType, boundRight.ResultType, binaryExpression.Operator.Kind);
 
         if (boundBinaryOperator is null)
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = $"Operator {binaryExpression.Operator.Text} is not supported on types {boundLeft.ResultType.Name} and {boundRight.ResultType.Name}",
@@ -110,7 +109,6 @@ public partial class Binder
             syntaxNode: binaryExpression,
             left: boundLeft,
             right: boundRight,
-            @operator: boundBinaryOperator,
-            diagnosticBuilder: diagnosticBuilder);
+            @operator: boundBinaryOperator);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBreakStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBreakStatement.cs
@@ -15,11 +15,9 @@ public partial class Binder
 {
     private BoundBreakStatement BindBreakStatement(BreakStatement breakStatement)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
-
         if (BoundLoopContext is null)
         {
-            diagnosticBuilder.Add(new Diagnostic()
+            ReportDiagnostic(new Diagnostic()
             {
                 Level = DiagnosticLevel.Error,
                 ErrorCode = ErrorCode.NoEnclosingLoop,
@@ -28,6 +26,6 @@ public partial class Binder
             });
         }
 
-        return BoundNodeFactory.CreateBoundBreakStatement(breakStatement, BoundLoopContext, diagnosticBuilder);
+        return BoundNodeFactory.CreateBoundBreakStatement(breakStatement, BoundLoopContext);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
@@ -57,8 +57,6 @@ public partial class Binder
     {
         Debug.Assert(boundBaseExpression.ResultType.IsNative);
 
-        var diagnosticBuilder = new DiagnosticBag.Builder();
-
         var type = (boundBaseExpression.ResultType as ClrTypeSymbol).ClrType;
         var isStatic = boundBaseExpression is BoundTypeExpression;
         var candidates = type
@@ -83,7 +81,7 @@ public partial class Binder
 
         if (candidate is null)
         {
-            ReportNoMatchingFunctionCandidate(diagnosticBuilder, functionCallExpression);
+            ReportNoMatchingFunctionCandidate(functionCallExpression);
         }
 
         var boundArguments = candidate
@@ -95,8 +93,7 @@ public partial class Binder
             syntaxNode: functionCallExpression,
             boundBaseExpression: boundBaseExpression,
             methodInfo: candidate,
-            boundArguments: boundArguments.ToImmutableArray(),
-            diagnosticBuilder: diagnosticBuilder);
+            boundArguments: boundArguments.ToImmutableArray());
     }
 
     private BoundClrFunctionCallExpression BindFunctionCallWithPositionalArgumentsInternal(
@@ -104,8 +101,6 @@ public partial class Binder
         FunctionCallExpression functionCallExpression)
     {
         Debug.Assert(boundBaseExpression.ResultType.IsNative);
-
-        var diagnosticBuilder = new DiagnosticBag.Builder();
 
         var boundArguments = functionCallExpression.Arguments.Items.Select(a => BindExpression(a.Expression));
         var type = (boundBaseExpression.ResultType as ClrTypeSymbol).ClrType;
@@ -119,22 +114,20 @@ public partial class Binder
 
         if (candidate is null)
         {
-            ReportNoMatchingFunctionCandidate(diagnosticBuilder, functionCallExpression);
+            ReportNoMatchingFunctionCandidate(functionCallExpression);
         }
 
         return BoundNodeFactory.CreateBoundClrFunctionCallExpression(
             syntaxNode: functionCallExpression,
             boundBaseExpression: boundBaseExpression,
             methodInfo: candidate,
-            boundArguments: boundArguments.ToImmutableArray(),
-            diagnosticBuilder: diagnosticBuilder);
+            boundArguments: boundArguments.ToImmutableArray());
     }
 
     private void ReportNoMatchingFunctionCandidate(
-        DiagnosticBag.Builder diagnosticBuilder,
         FunctionCallExpression functionCallExpression)
     {
-        diagnosticBuilder.Add(
+        ReportDiagnostic(
             new Diagnostic()
             {
                 Message = $"No matching function '{functionCallExpression.NameToken.Text}' found.",

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConstant.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConstant.cs
@@ -150,8 +150,7 @@ public partial class Binder
 
     private BoundConstant ReportUnsupportedLiteral(LiteralExpression literalExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
-        diagnosticBuilder.Add(
+        ReportDiagnostic(
             new Diagnostic()
             {
                 Message = $"Literal value {literalExpression.Text} is not supported",
@@ -162,7 +161,6 @@ public partial class Binder
 
         return BoundNodeFactory.CreateBoundConstant(
             syntaxNode: literalExpression,
-            value: ConstantValueFactory.Null,
-            diagnosticBuilder: diagnosticBuilder);
+            value: ConstantValueFactory.Null);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundContinueStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundContinueStatement.cs
@@ -15,11 +15,9 @@ public partial class Binder
 {
     private BoundContinueStatement BindContinueStatement(ContinueStatement continueStatement)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
-
         if (BoundLoopContext is null)
         {
-            diagnosticBuilder.Add(new Diagnostic()
+            ReportDiagnostic(new Diagnostic()
             {
                 Level = DiagnosticLevel.Error,
                 ErrorCode = ErrorCode.NoEnclosingLoop,
@@ -28,6 +26,6 @@ public partial class Binder
             });
         }
 
-        return BoundNodeFactory.CreateBoundContinueStatement(continueStatement, BoundLoopContext, diagnosticBuilder);
+        return BoundNodeFactory.CreateBoundContinueStatement(continueStatement, BoundLoopContext);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
@@ -64,7 +64,6 @@ public partial class Binder
     internal BoundEntryPointTypeDefinition BindEntryPointTypeDefinition(IEnumerable<SyntaxTree> syntaxTrees)
     {
         var typeBinder = CreateTypeBinder();
-        var diagnosticBuilder = new DiagnosticBag.Builder();
 
         var members = syntaxTrees.SelectMany(tree => tree.Members);
         foreach (var functionDeclarationMember in members.OfType<FunctionDeclarationMember>())
@@ -72,7 +71,7 @@ public partial class Binder
             var function = FunctionSymbol.FromFunctionDeclarationMember(functionDeclarationMember);
             if (typeBinder.Scope.DeclareFunction(function) != function)
             {
-                diagnosticBuilder.Add(new Diagnostic()
+                ReportDiagnostic(new Diagnostic()
                 {
                     Message = "Ambiguous function declaration. Multiple functions with the same name and parameters set are declared within the same scope.",
                     ErrorCode = ErrorCode.AmbiguousFunctionDeclaration,
@@ -83,14 +82,12 @@ public partial class Binder
         }
 
         var boundMembers = members.Select(m => typeBinder.BindMember(m));
-        diagnosticBuilder.AddRange(boundMembers);
 
         // TODO: Use BoundNodeFactory to create BoundEntryPointTypeDefinition
         return new()
         {
             SyntaxNode = null,
-            BoundMembers = boundMembers.ToImmutableArray(),
-            DiagnosticBuilder = diagnosticBuilder
+            BoundMembers = boundMembers.ToImmutableArray()
         };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
@@ -23,7 +23,6 @@ public partial class Binder
 {
     private BoundFunctionMember BindFunctionDeclarationMember(FunctionDeclarationMember functionDeclarationMember)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var functionSymbol = Scope.LookupFunctionSymbol(functionDeclarationMember);
         var functionBinder = CreateFunctionBinder(functionSymbol);
 
@@ -34,7 +33,7 @@ public partial class Binder
 
         if (duplicate is not null)
         {
-            diagnosticBuilder.Add(new Diagnostic()
+            ReportDiagnostic(new Diagnostic()
             {
                 Message = $"Parameter '{duplicate.First().Name}' is a duplicate",
                 ErrorCode = ErrorCode.DuplicateParameterName,
@@ -55,8 +54,7 @@ public partial class Binder
             {
                 var returnStatement = BoundNodeFactory.CreateBoundReturnStatement(
                     syntaxNode: null,
-                    boundReturnValueExpression: null,
-                    diagnosticBuilder: diagnosticBuilder);
+                    boundReturnValueExpression: null);
 
                 body = BoundNodeFactory.CreateBoundBlockStatement(
                     syntaxNode: body.SyntaxNode,
@@ -69,7 +67,6 @@ public partial class Binder
             syntaxNode: functionDeclarationMember,
             functionScope: functionBinder.Scope,
             body: body,
-            functionSymbol: functionSymbol,
-            diagnosticBuilder: diagnosticBuilder);
+            functionSymbol: functionSymbol);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
@@ -22,11 +22,10 @@ public partial class Binder
         var condition = loopBinder.BindExpression(whileUntilStatement.ConditionExpression);
         var body = loopBinder.BindBlockStatementInScope(whileUntilStatement.BlockStatement);
         var negated = whileUntilStatement.WhileOrUntilToken.Kind == SyntaxKind.UntilKeywordToken;
-        var diagnosticBuilder = new DiagnosticBag.Builder();
 
         if (condition.ResultType.SpecialType != Symbols.SpecialType.ClrBoolean)
         {
-            diagnosticBuilder.Add(new Diagnostic()
+            ReportDiagnostic(new Diagnostic()
             {
                 ErrorCode = ErrorCode.TypeMismatch,
                 Level = DiagnosticLevel.Error,
@@ -40,7 +39,6 @@ public partial class Binder
             condition: condition,
             conditionNegated: negated,
             body: body,
-            boundLoopContext: loopBinder.BoundLoopContext,
-            diagnosticBuilder: diagnosticBuilder);
+            boundLoopContext: loopBinder.BoundLoopContext);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
@@ -73,7 +73,6 @@ public partial class Binder
     private BoundMemberAccessExpression BindMemberAccessExpression(
         MemberAccessExpression memberAccessExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var boundBaseExpression = BindExpression(memberAccessExpression.BaseExpression);
 
         if (boundBaseExpression.ResultType is not ClrTypeSymbol clrTypeSymbol)
@@ -89,12 +88,11 @@ public partial class Binder
                 var boundFieldAccessExpression = BoundNodeFactory.CreateBoundClrFieldAccessExpression(
                     syntaxNode: memberAccessExpression,
                     boundBaseExpression: boundBaseExpression,
-                    fieldInfo: fieldInfo,
-                    diagnosticBuilder: diagnosticBuilder);
+                    fieldInfo: fieldInfo);
 
                 if (!boundFieldAccessExpression.IsPublic)
                 {
-                    ReportNonPublicMemberAccess(boundFieldAccessExpression, diagnosticBuilder);
+                    ReportNonPublicMemberAccess(boundFieldAccessExpression);
                 }
 
                 return boundFieldAccessExpression;
@@ -102,18 +100,17 @@ public partial class Binder
                 var boundPropertyAccessExpression = BoundNodeFactory.CreateBoundClrPropertyAccessExpression(
                     syntaxNode: memberAccessExpression,
                     boundBaseExpression: boundBaseExpression,
-                    propertyInfo: propertyInfo,
-                    diagnosticBuilder: diagnosticBuilder);
+                    propertyInfo: propertyInfo);
 
                 if (!boundPropertyAccessExpression.IsPublic)
                 {
-                    ReportNonPublicMemberAccess(boundPropertyAccessExpression, diagnosticBuilder);
+                    ReportNonPublicMemberAccess(boundPropertyAccessExpression);
                 }
 
                 return boundPropertyAccessExpression;
         }
 
-        diagnosticBuilder.Add(
+        ReportDiagnostic(
             new Diagnostic()
             {
                 Message = $"Member '{memberAccessExpression.MemberIdentifierToken.Text}' does not exist in type '{clrTypeSymbol.ClrType.FullName}'",
@@ -124,13 +121,12 @@ public partial class Binder
 
         return BoundNodeFactory.CreateBoundInvalidMemberAccessExpression(
             syntaxNode: memberAccessExpression,
-            boundBaseExpression: boundBaseExpression,
-            diagnosticBuilder: diagnosticBuilder);
+            boundBaseExpression: boundBaseExpression);
     }
 
-    private void ReportNonPublicMemberAccess(BoundMemberAccessExpression boundMemberAccessExpression, DiagnosticBag.Builder diagnosticBuilder)
+    private void ReportNonPublicMemberAccess(BoundMemberAccessExpression boundMemberAccessExpression)
     {
-        diagnosticBuilder.Add(
+        ReportDiagnostic(
             new Diagnostic()
             {
                 Message = $"Member {boundMemberAccessExpression.MemberName} is not public.",

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNode.cs
@@ -4,21 +4,10 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
-internal abstract class BoundNode : IDiagnosable
+internal abstract class BoundNode
 {
     public SyntaxNode SyntaxNode { get; internal init; }
-    public DiagnosticBag.Builder DiagnosticBuilder { get; internal init; }
 
     public abstract BoundNode Accept(BoundTreeVisitor visitor);
 
-    public virtual IEnumerable<Diagnostic> GetDiagnostics()
-    {
-        if (DiagnosticBuilder == null)
-        {
-            return DiagnosticBag.Empty;
-
-        }
-
-        return DiagnosticBuilder.Build();
-    }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundReturnStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundReturnStatement.cs
@@ -32,7 +32,7 @@ public partial class Binder
 
         if (!IsInFunction)
         {
-            boundReturnStatement.DiagnosticBuilder.Add(new Diagnostic()
+            ReportDiagnostic(new Diagnostic()
             {
                 Message = "Return statements are only valid within a function declaration.",
                 ErrorCode = ErrorCode.UnexpectedStatement,
@@ -42,7 +42,7 @@ public partial class Binder
         }
         else if (!boundReturnStatement.ReturnType.Equals(FunctionSymbol.ReturnType))
         {
-            boundReturnStatement.DiagnosticBuilder.Add(new Diagnostic()
+            ReportDiagnostic(new Diagnostic()
             {
                 Message = $"The function expects a return type of {FunctionSymbol.ReturnType} but {boundReturnStatement.ReturnType} is returned.",
                 ErrorCode = ErrorCode.TypeMismatch,

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTodlFunctionCallExpression.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
-using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 
@@ -22,7 +21,6 @@ public partial class Binder
 {
     private BoundTodlFunctionCallExpression BindTodlFunctionCallExpression(FunctionCallExpression functionCallExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         FunctionSymbol functionSymbol = null;
         var boundArguments = ImmutableDictionary<string, BoundExpression>.Empty;
 
@@ -54,13 +52,12 @@ public partial class Binder
 
         if (functionSymbol == null)
         {
-            ReportNoMatchingFunctionCandidate(diagnosticBuilder, functionCallExpression);
+            ReportNoMatchingFunctionCandidate(functionCallExpression);
         }
 
         return BoundNodeFactory.CreateBoundTodlFunctionCallExpression(
             syntaxNode: functionCallExpression,
             functionSymbol: functionSymbol,
-            boundArguments: boundArguments,
-            diagnosticBuilder: diagnosticBuilder);
+            boundArguments: boundArguments);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundUnaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundUnaryExpression.cs
@@ -214,7 +214,6 @@ public partial class Binder
 {
     private BoundUnaryExpression BindUnaryExpression(UnaryExpression unaryExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var boundOperand = BindExpression(unaryExpression.Operand);
         var boundUnaryOperator = BoundUnaryOperator.Create(
             operandType: boundOperand.ResultType,
@@ -223,7 +222,7 @@ public partial class Binder
 
         if (boundUnaryOperator is null)
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = $"Unary operator \"{unaryExpression.Operator.Text}\" is not supported on type \"{boundOperand.ResultType.Name}\"",
@@ -235,7 +234,7 @@ public partial class Binder
 
         if (!boundOperand.LValue && boundUnaryOperator.BoundUnaryOperatorKind.HasSideEffect())
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = $"Unary operator \"{unaryExpression.Operator.Text}\" requires an lvalue.",
@@ -246,7 +245,7 @@ public partial class Binder
         }
         else if (boundOperand.ReadOnly && boundUnaryOperator.BoundUnaryOperatorKind.HasSideEffect())
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = $"Expression \"{unaryExpression.Operand.Text}\" is read only.",
@@ -259,7 +258,6 @@ public partial class Binder
         return BoundNodeFactory.CreateBoundUnaryExpression(
             syntaxNode: unaryExpression,
             operand: boundOperand,
-            @operator: boundUnaryOperator,
-            diagnosticBuilder: diagnosticBuilder);
+            @operator: boundUnaryOperator);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableExpression.cs
@@ -30,11 +30,10 @@ public partial class Binder
                 targetType: type);
         }
 
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var variable = Scope.LookupVariable(name);
         if (variable == null)
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = $"Undeclared variable {nameExpression.Text}",
@@ -46,7 +45,6 @@ public partial class Binder
 
         return BoundNodeFactory.CreateBoundVariableExpression(
             syntaxNode: nameExpression,
-            variable: variable,
-            diagnosticBuilder: diagnosticBuilder);
+            variable: variable);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/ConstantFoldingBoundNodeVisitor.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/ConstantFoldingBoundNodeVisitor.cs
@@ -36,8 +36,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
             syntaxNode: boundBinaryExpression.SyntaxNode,
             @operator: boundBinaryExpression.Operator,
             left: left,
-            right: right,
-            diagnosticBuilder: boundBinaryExpression.DiagnosticBuilder);
+            right: right);
     }
 
     private BoundExpression FoldBinaryConstant(BoundConstant left, BoundConstant right, BoundBinaryExpression boundBinaryExpression)
@@ -107,8 +106,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
 
         return BoundNodeFactory.CreateBoundConstant(
             syntaxNode: boundBinaryExpression.SyntaxNode,
-            value: value,
-            diagnosticBuilder: boundBinaryExpression.DiagnosticBuilder);
+            value: value);
     }
 
     protected override BoundExpression VisitBoundUnaryExpression(BoundUnaryExpression boundUnaryExpression)
@@ -155,8 +153,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
 
             return BoundNodeFactory.CreateBoundConstant(
                 syntaxNode: boundUnaryExpression.SyntaxNode,
-                value: value,
-                diagnosticBuilder: boundUnaryExpression.DiagnosticBuilder);
+                value: value);
         };
 
         if (visitedOperand == boundUnaryExpression.Operand)
@@ -167,8 +164,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
         return BoundNodeFactory.CreateBoundUnaryExpression(
             syntaxNode: boundUnaryExpression.SyntaxNode,
             @operator: boundUnaryExpression.Operator,
-            operand: visitedOperand,
-            diagnosticBuilder: boundUnaryExpression.DiagnosticBuilder);
+            operand: visitedOperand);
     }
 
     protected override BoundStatement VisitBoundVariableDeclarationStatement(BoundVariableDeclarationStatement boundVariableDeclarationStatement)
@@ -187,8 +183,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
             return BoundNodeFactory.CreateBoundVariableDeclarationStatement(
                 syntaxNode: boundVariableDeclarationStatement.SyntaxNode,
                 variable: boundVariableDeclarationStatement.Variable,
-                initializerExpression: constant,
-                diagnosticBuilder: boundVariableDeclarationStatement.DiagnosticBuilder);
+                initializerExpression: constant);
         }
 
         if (visitedExpression == boundVariableDeclarationStatement.InitializerExpression)
@@ -199,8 +194,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
         return BoundNodeFactory.CreateBoundVariableDeclarationStatement(
             syntaxNode: boundVariableDeclarationStatement.SyntaxNode,
             variable: boundVariableDeclarationStatement.Variable,
-            initializerExpression: visitedExpression,
-            diagnosticBuilder: boundVariableDeclarationStatement.DiagnosticBuilder);
+            initializerExpression: visitedExpression);
     }
 
     protected override BoundStatement VisitBoundReturnStatement(BoundReturnStatement boundReturnStatement)
@@ -218,8 +212,7 @@ internal sealed class ConstantFoldingBoundNodeVisitor : BoundNodeVisitor
 
         return BoundNodeFactory.CreateBoundReturnStatement(
             syntaxNode: boundReturnStatement.SyntaxNode,
-            boundReturnValueExpression: boundReturnValueExpression,
-            diagnosticBuilder: boundReturnStatement.DiagnosticBuilder);
+            boundReturnValueExpression: boundReturnValueExpression);
     }
 
     protected override BoundExpression VisitBoundVariableExpression(BoundVariableExpression boundVariableExpression)

--- a/src/Todl.Compiler/Evaluation/Evaluator.cs
+++ b/src/Todl.Compiler/Evaluation/Evaluator.cs
@@ -8,6 +8,7 @@ using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.CodeAnalysis.Text;
+using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.Evaluation
 {
@@ -46,12 +47,13 @@ namespace Todl.Compiler.Evaluation
                 };
             }
 
-            var binder = Binder.CreateScriptBinder(clrTypeCache);
+            var diagnosticBuilder = new DiagnosticBag.Builder();
+            var binder = Binder.CreateScriptBinder(clrTypeCache, diagnosticBuilder);
             var boundExpression = binder.BindExpression(expression);
 
             return new()
             {
-                DiagnosticsOutput = boundExpression.GetDiagnostics().Select(d => d.Message).ToList(),
+                DiagnosticsOutput = diagnosticBuilder.Build().Select(d => d.Message).ToList(),
                 EvaluationOutput = EvaluateBoundExpression(boundExpression),
                 ResultType = boundExpression.ResultType
             };


### PR DESCRIPTION
This PR refactors the `Binder` code so that `BoundNode`s no longer carry their own `DiagnosticBag`s. Instead, `DiagnosticBag`s are centrally managed at the application level and are injected into `Binder`s and analyzers/rewriters. This should result in significantly reduced allocations of `DiagnosticBag` objects, especially when `BoundNode`s are being re-written. A similar change will be coming to `SyntaxNode`s as well.