### PR TITLE
Remove DiagnosticBag from SyntaxNode

### DIFF
--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundNodeTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundNodeTests.cs
@@ -113,7 +113,7 @@ public sealed class BoundNodeTests
 
         foreach (var inputText in testExpressions)
         {
-            var expression = SyntaxTree.ParseExpression(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var expression = SyntaxTree.ParseExpression(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             var binder = Binder.CreateScriptBinder(TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             yield return new object[] { expression, binder.BindExpression(expression) };
         }
@@ -121,7 +121,7 @@ public sealed class BoundNodeTests
         // BoundVariableExpression requires special logic to work
         {
             var sourceText = SourceText.FromString("{ const a = 5; a; }");
-            var blockStatement = SyntaxTree.ParseStatement(sourceText, TestDefaults.DefaultClrTypeCache);
+            var blockStatement = SyntaxTree.ParseStatement(sourceText, TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             var binder = Binder.CreateModuleBinder(TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             var boundBlockStatement =
                 binder.BindStatement(blockStatement).As<BoundBlockStatement>();
@@ -133,14 +133,14 @@ public sealed class BoundNodeTests
 
         foreach (var inputText in testStatements)
         {
-            var statement = SyntaxTree.ParseStatement(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var statement = SyntaxTree.ParseStatement(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             var binder = Binder.CreateModuleBinder(TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             yield return new object[] { statement, binder.BindStatement(statement) };
         }
 
         foreach (var inputText in testMembers)
         {
-            var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             var member = syntaxTree.Members[0];
             var binder = Binder.CreateModuleBinder(TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             if (member is FunctionDeclarationMember functionDeclarationMember)

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/ConstantFoldingTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/ConstantFoldingTests.cs
@@ -30,7 +30,7 @@ public sealed class ConstantFoldingTests
     [InlineData("const a = ~10UL;", ~10UL)]
     public void ConstantFoldingUnaryOperatorTest(string inputText, object expectedValue)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, new());
         var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
         module.GetDiagnostics().Should().BeEmpty();
 
@@ -54,7 +54,7 @@ public sealed class ConstantFoldingTests
     [InlineData("const a = -20;", -20)]
     public void BasicConstantFoldingTests(string inputText, object expectedValue)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, new());
         var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
         module.GetDiagnostics().Should().BeEmpty();
 
@@ -76,7 +76,7 @@ public sealed class ConstantFoldingTests
     [InlineData("const a = 10; let b = a + 10; const c = a + b;")]
     public void BasicConstantFoldingNegativeTests(string inputText)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, new());
         var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
         module.GetDiagnostics().Should().BeEmpty();
 
@@ -88,7 +88,7 @@ public sealed class ConstantFoldingTests
     [Fact]
     public void PartiallyFoldedConstantTests()
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString("let a = 10 + 10;"), TestDefaults.DefaultClrTypeCache);
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString("let a = 10 + 10;"), TestDefaults.DefaultClrTypeCache, new());
         var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
         module.GetDiagnostics().Should().BeEmpty();
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ClrTypeCacheViewTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ClrTypeCacheViewTests.cs
@@ -52,7 +52,7 @@ public sealed class ClrTypeCacheViewTests
     [InlineData("System.Uri", "import { Console, Uri } from System;", typeof(Uri))]
     public void TestResolveImportedTypes(string typeName, string importDirective, Type targetType)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(importDirective), TestDefaults.DefaultClrTypeCache);
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(importDirective), TestDefaults.DefaultClrTypeCache, new());
         var resolvedType = syntaxTree.ClrTypeCacheView.ResolveBaseType(typeName);
         resolvedType.ClrType.AssemblyQualifiedName.Should().Be(targetType.AssemblyQualifiedName);
         resolvedType.SpecialType.Should().Be(SpecialType.None);

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/IfUnlessStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/IfUnlessStatementTests.cs
@@ -82,7 +82,6 @@ public sealed class IfUnlessStatementTests
         var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>(inputText);
         ifUnlessStatement.Should().NotBeNull();
         ifUnlessStatement.ElseClauses.Should().HaveCount(expectedCount);
-        ifUnlessStatement.GetDiagnostics().Should().BeEmpty();
     }
 
     [Theory]
@@ -93,17 +92,17 @@ public sealed class IfUnlessStatementTests
         var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>(inputText);
         ifUnlessStatement.Should().NotBeNull();
         ifUnlessStatement.ElseClauses.Should().HaveCount(1);
-        ifUnlessStatement.GetDiagnostics().Should().BeEmpty();
     }
 
     [Fact]
     public void IfUnlessStatementsCannotHaveMoreThanOneBareElseClauses()
     {
-        var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>("if a == 0 { } else { } else { }");
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>("if a == 0 { } else { } else { }", diagnosticBuilder);
         ifUnlessStatement.Should().NotBeNull();
         ifUnlessStatement.ElseClauses.Should().HaveCount(2);
 
-        var diagnostics = ifUnlessStatement.GetDiagnostics();
+        var diagnostics = diagnosticBuilder.Build();
         diagnostics.Should().NotBeEmpty();
         diagnostics.Count(d => d.ErrorCode == ErrorCode.DuplicateBareElseClauses).Should().Be(2);
 
@@ -116,11 +115,12 @@ public sealed class IfUnlessStatementTests
     [Fact]
     public void IfUnlessStatementsCannotHaveMisplacedElseClause()
     {
-        var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>("if a == 0 { } else { } else if b == 0 { }");
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>("if a == 0 { } else { } else if b == 0 { }", diagnosticBuilder);
         ifUnlessStatement.Should().NotBeNull();
         ifUnlessStatement.ElseClauses.Should().HaveCount(2);
 
-        var diagnostics = ifUnlessStatement.GetDiagnostics();
+        var diagnostics = diagnosticBuilder.Build();
         diagnostics.Should().NotBeEmpty();
         diagnostics.Count(d => d.ErrorCode == ErrorCode.MisplacedBareElseClauses).Should().Be(1);
 
@@ -133,11 +133,12 @@ public sealed class IfUnlessStatementTests
     [Fact]
     public void IfUnlessStatementsCannotHaveMismatchedIfOrUnlessKeywords()
     {
-        var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>("if a == 0 { } else unless b == 0 { }");
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var ifUnlessStatement = TestUtils.ParseStatement<IfUnlessStatement>("if a == 0 { } else unless b == 0 { }", diagnosticBuilder);
         ifUnlessStatement.Should().NotBeNull();
         ifUnlessStatement.ElseClauses.Should().HaveCount(1);
 
-        var diagnostics = ifUnlessStatement.GetDiagnostics();
+        var diagnostics = diagnosticBuilder.Build();
         diagnostics.Should().NotBeEmpty();
         diagnostics.Count(d => d.ErrorCode == ErrorCode.IfUnlessKeywordMismatch).Should().Be(1);
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/SyntaxNodeTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/SyntaxNodeTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.CodeAnalysis.Text;
+using Todl.Compiler.Diagnostics;
 using Xunit;
 
 namespace Todl.Compiler.Tests.CodeAnalysis;
@@ -24,14 +25,6 @@ public sealed class SyntaxNodeTests
     public void SyntaxTreePropertyShouldNotBeNull(string inputTextIgnored, SyntaxNode syntaxNode)
     {
         syntaxNode.SyntaxTree.Should().NotBeNull();
-    }
-
-    [Theory]
-    [MemberData(nameof(GetAllSyntaxNodesForTest))]
-    [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
-    public void DiagnosticBagShouldNotBeNull(string inputTextIgnored, SyntaxNode syntaxNode)
-    {
-        syntaxNode.GetDiagnostics().Should().NotBeNull();
     }
 
     [Fact]
@@ -99,27 +92,29 @@ public sealed class SyntaxNodeTests
 
     public static IEnumerable<object[]> GetAllSyntaxNodesForTest()
     {
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+
         foreach (var inputText in testExpressions)
         {
-            var expression = SyntaxTree.ParseExpression(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var expression = SyntaxTree.ParseExpression(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             yield return new object[] { inputText, expression };
         }
 
         foreach (var inputText in testStatements)
         {
-            var statement = SyntaxTree.ParseStatement(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var statement = SyntaxTree.ParseStatement(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             yield return new object[] { inputText, statement };
         }
 
         foreach (var inputText in testDirectives)
         {
-            var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             yield return new object[] { inputText, syntaxTree.Directives[0] };
         }
 
         foreach (var inputText in testMembers)
         {
-            var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+            var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
             yield return new object[] { inputText, syntaxTree.Members[0] };
         }
     }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
@@ -11,7 +11,6 @@ public sealed class WhileUntilStatementTests
     {
         var breakStatement = TestUtils.ParseStatement<BreakStatement>("break;");
         breakStatement.Should().NotBeNull();
-        breakStatement.GetDiagnostics().Should().BeEmpty();
 
         breakStatement.BreakKeywordToken.Kind.Should().Be(SyntaxKind.BreakKeywordToken);
         breakStatement.SemicolonToken.Kind.Should().Be(SyntaxKind.SemicolonToken);
@@ -23,7 +22,6 @@ public sealed class WhileUntilStatementTests
     {
         var continueStatement = TestUtils.ParseStatement<ContinueStatement>("continue;");
         continueStatement.Should().NotBeNull();
-        continueStatement.GetDiagnostics().Should().BeEmpty();
 
         continueStatement.ContinueKeywordToken.Kind.Should().Be(SyntaxKind.ContinueKeywordToken);
         continueStatement.SemicolonToken.Kind.Should().Be(SyntaxKind.SemicolonToken);
@@ -37,7 +35,6 @@ public sealed class WhileUntilStatementTests
     {
         var whileUntilStatement = TestUtils.ParseStatement<WhileUntilStatement>(inputText);
         whileUntilStatement.Should().NotBeNull();
-        whileUntilStatement.GetDiagnostics().Should().BeEmpty();
 
         whileUntilStatement.WhileOrUntilToken.Kind.Should().Be(expectedSyntaxKind);
         whileUntilStatement.BlockStatement.InnerStatements.Should().BeEmpty();
@@ -56,7 +53,6 @@ public sealed class WhileUntilStatementTests
     {
         var whileUntilStatement = TestUtils.ParseStatement<WhileUntilStatement>(inputText);
         whileUntilStatement.Should().NotBeNull();
-        whileUntilStatement.GetDiagnostics().Should().BeEmpty();
         whileUntilStatement.BlockStatement.InnerStatements.Should().HaveCount(expectedStatementsCount);
     }
 }

--- a/src/Todl.Compiler.Tests/TestUtils.cs
+++ b/src/Todl.Compiler.Tests/TestUtils.cs
@@ -21,7 +21,7 @@ internal static class TestUtils
         string inputText, DiagnosticBag.Builder diagnosticBuilder)
         where TBoundExpression : BoundExpression
     {
-        var expression = SyntaxTree.ParseExpression(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+        var expression = SyntaxTree.ParseExpression(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
         var binder = Binder.CreateModuleBinder(TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
         return binder.BindExpression(expression).As<TBoundExpression>();
     }
@@ -39,7 +39,7 @@ internal static class TestUtils
         string inputText, DiagnosticBag.Builder diagnosticBuilder)
         where TBoundStatement : BoundStatement
     {
-        var statement = SyntaxTree.ParseStatement(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+        var statement = SyntaxTree.ParseStatement(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
         var binder = Binder.CreateModuleBinder(TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
         return binder.BindStatement(statement).As<TBoundStatement>();
     }
@@ -104,33 +104,79 @@ internal static class TestUtils
         emitter.ILProcessor.Body.Instructions.ShouldHaveExactInstructionSequence(expectedInstructions);
     }
 
+    internal static SyntaxTree ParseSyntaxTree(string inputText, DiagnosticBag.Builder diagnosticBuilder)
+        => SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
+
     internal static SyntaxTree ParseSyntaxTree(string inputText)
-        => SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache);
+    {
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var syntaxTree = ParseSyntaxTree(inputText, diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
+        return syntaxTree;
+    }
+
+    internal static TExpression ParseExpression<TExpression>(string sourceText, DiagnosticBag.Builder diagnosticBuilder)
+        where TExpression : Expression
+        => SyntaxTree.ParseExpression(
+            SourceText.FromString(sourceText),
+            TestDefaults.DefaultClrTypeCache,
+            diagnosticBuilder).As<TExpression>();
 
     internal static TExpression ParseExpression<TExpression>(string sourceText)
-            where TExpression : Expression
+        where TExpression : Expression
     {
-        return SyntaxTree.ParseExpression(SourceText.FromString(sourceText), TestDefaults.DefaultClrTypeCache).As<TExpression>();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var expression = ParseExpression<TExpression>(sourceText, diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
+        return expression;
     }
+
+    internal static TStatement ParseStatement<TStatement>(string sourceText, DiagnosticBag.Builder diagnosticBuilder)
+        where TStatement : Statement
+        => SyntaxTree.ParseStatement(
+            SourceText.FromString(sourceText),
+            TestDefaults.DefaultClrTypeCache,
+            diagnosticBuilder).As<TStatement>();
 
     internal static TStatement ParseStatement<TStatement>(string sourceText)
         where TStatement : Statement
     {
-        return SyntaxTree.ParseStatement(SourceText.FromString(sourceText), TestDefaults.DefaultClrTypeCache).As<TStatement>();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var statement = ParseStatement<TStatement>(sourceText, diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
+        return statement;
     }
+
+    internal static TDirective ParseDirective<TDirective>(string sourceText, DiagnosticBag.Builder diagnosticBuilder)
+        where TDirective : Directive
+        => SyntaxTree.Parse(
+            SourceText.FromString(sourceText),
+            TestDefaults.DefaultClrTypeCache,
+            diagnosticBuilder).Directives[0].As<TDirective>();
 
     internal static TDirective ParseDirective<TDirective>(string sourceText)
         where TDirective : Directive
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(sourceText), TestDefaults.DefaultClrTypeCache);
-        return syntaxTree.Directives[0].As<TDirective>();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var directive = ParseDirective<TDirective>(sourceText, diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
+        return directive;
     }
+
+    internal static TMember ParseMember<TMember>(string sourceText, DiagnosticBag.Builder diagnosticBuilder)
+        where TMember : Member
+        => SyntaxTree.Parse(
+            SourceText.FromString(sourceText),
+            TestDefaults.DefaultClrTypeCache,
+            diagnosticBuilder).Members[0].As<TMember>();
 
     internal static TMember ParseMember<TMember>(string sourceText)
         where TMember : Member
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(sourceText), TestDefaults.DefaultClrTypeCache);
-        return syntaxTree.Members[0].As<TMember>();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var member = ParseMember<TMember>(sourceText, diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
+        return member;
     }
 
     internal static void ShouldHaveExactInstructionSequence(

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
@@ -17,9 +17,14 @@ internal sealed class BoundModule : IDiagnosable
     public static BoundModule Create(
         ClrTypeCache clrTypeCache,
         IReadOnlyList<SyntaxTree> syntaxTrees)
+        => Create(clrTypeCache, syntaxTrees, new());
+
+    public static BoundModule Create(
+        ClrTypeCache clrTypeCache,
+        IReadOnlyList<SyntaxTree> syntaxTrees,
+        DiagnosticBag.Builder diagnosticBuilder)
     {
         syntaxTrees ??= Array.Empty<SyntaxTree>();
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var binder = Binder.CreateModuleBinder(clrTypeCache, diagnosticBuilder);
         var entryPointType = binder.BindEntryPointTypeDefinition(syntaxTrees);
 

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionCallExpression.cs
@@ -72,13 +72,12 @@ public sealed partial class Parser
 
     private FunctionCallExpression ParseFunctionCallExpression(Expression baseExpression)
     {
-        var diagnosticBuilder = new DiagnosticBag.Builder();
         var arguments = ParseCommaSeparatedSyntaxList(ParseArgument);
 
         var namedArguments = arguments.Items.Where(p => p.IsNamedArgument);
         if (namedArguments.Any() && namedArguments.Count() != arguments.Items.Length)
         {
-            diagnosticBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = "Either all or none of the arguments should be named arguments",
@@ -96,8 +95,7 @@ public sealed partial class Parser
                 BaseExpression = memberAccessExpression.BaseExpression,
                 DotToken = memberAccessExpression.DotToken,
                 NameToken = memberAccessExpression.MemberIdentifierToken,
-                Arguments = arguments,
-                DiagnosticBuilder = diagnosticBuilder
+                Arguments = arguments
             };
         }
 
@@ -107,8 +105,7 @@ public sealed partial class Parser
         {
             SyntaxTree = syntaxTree,
             NameToken = (baseExpression as NameExpression).SyntaxTokens[0],
-            Arguments = arguments,
-            DiagnosticBuilder = diagnosticBuilder
+            Arguments = arguments
         };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/IfUnlessStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/IfUnlessStatement.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
@@ -47,14 +46,13 @@ public sealed partial class Parser
         var conditionExpression = ParseExpression();
         var blockStatement = ParseBlockStatement();
         var elseClauses = ImmutableArray.CreateBuilder<ElseClause>();
-        var diagnosticBuilder = new DiagnosticBag.Builder();
 
         while (Current.Kind == SyntaxKind.ElseKeywordToken)
         {
             var elseClause = ParseElseClause();
             if (elseClause.IfOrUnlessToken.HasValue && elseClause.IfOrUnlessToken.Value.Kind != ifOrUnlessToken.Kind)
             {
-                diagnosticBuilder.Add(new Diagnostic()
+                ReportDiagnostic(new Diagnostic()
                 {
                     Message = "if/unless qualifier mismatch",
                     ErrorCode = ErrorCode.IfUnlessKeywordMismatch,
@@ -74,7 +72,7 @@ public sealed partial class Parser
             {
                 foreach (var b in bareElseClauses)
                 {
-                    diagnosticBuilder.Add(new Diagnostic()
+                    ReportDiagnostic(new Diagnostic()
                     {
                         Message = "bare else clauses must be after all other else clauses",
                         ErrorCode = ErrorCode.MisplacedBareElseClauses,
@@ -88,7 +86,7 @@ public sealed partial class Parser
             {
                 foreach (var b in bareElseClauses)
                 {
-                    diagnosticBuilder.Add(new Diagnostic()
+                    ReportDiagnostic(new Diagnostic()
                     {
                         Message = "duplicate bare else clauses",
                         ErrorCode = ErrorCode.DuplicateBareElseClauses,
@@ -105,8 +103,7 @@ public sealed partial class Parser
             IfOrUnlessToken = ifOrUnlessToken,
             ConditionExpression = conditionExpression,
             BlockStatement = blockStatement,
-            ElseClauses = elseClauses.ToImmutable(),
-            DiagnosticBuilder = diagnosticBuilder
+            ElseClauses = elseClauses.ToImmutable()
         };
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/NewExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/NewExpression.cs
@@ -17,7 +17,6 @@ public sealed partial class Parser
 {
     private NewExpression ParseNewExpression()
     {
-        var diagnosticsBuilder = new DiagnosticBag.Builder();
         var newKeywordToken = ExpectToken(SyntaxKind.NewKeywordToken);
         var typeNameExpression = ParseNameExpression();
         var arguments = ParseCommaSeparatedSyntaxList(ParseArgument);
@@ -25,7 +24,7 @@ public sealed partial class Parser
         var namedArguments = arguments.Items.Where(p => p.IsNamedArgument);
         if (namedArguments.Any() && namedArguments.Count() != arguments.Items.Length)
         {
-            diagnosticsBuilder.Add(
+            ReportDiagnostic(
                 new Diagnostic()
                 {
                     Message = "Either all or none of the arguments should be named arguments",
@@ -40,8 +39,7 @@ public sealed partial class Parser
             SyntaxTree = syntaxTree,
             NewKeywordToken = newKeywordToken,
             TypeNameExpression = typeNameExpression,
-            Arguments = arguments,
-            DiagnosticBuilder = diagnosticsBuilder
+            Arguments = arguments
         };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
@@ -10,6 +10,7 @@ namespace Todl.Compiler.CodeAnalysis.Syntax;
 public sealed partial class Parser
 {
     private readonly SyntaxTree syntaxTree;
+    private readonly DiagnosticBag.Builder diagnosticBuilder;
     private readonly ImmutableArray<Directive>.Builder directives
         = ImmutableArray.CreateBuilder<Directive>();
     private readonly ImmutableArray<Member>.Builder members
@@ -74,9 +75,10 @@ public sealed partial class Parser
         return ExpectToken(syntaxKind);
     }
 
-    internal Parser(SyntaxTree syntaxTree)
+    internal Parser(SyntaxTree syntaxTree, DiagnosticBag.Builder diagnosticBuilder)
     {
         this.syntaxTree = syntaxTree;
+        this.diagnosticBuilder = diagnosticBuilder;
     }
 
     public void Parse()
@@ -166,4 +168,7 @@ public sealed partial class Parser
             ErrorCode = ErrorCode.UnexpectedToken
         };
     }
+
+    private void ReportDiagnostic(Diagnostic diagnostic)
+        => diagnosticBuilder.Add(diagnostic);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -1,23 +1,9 @@
-﻿using System.Collections.Generic;
-using Todl.Compiler.CodeAnalysis.Text;
-using Todl.Compiler.Diagnostics;
+﻿using Todl.Compiler.CodeAnalysis.Text;
 
-namespace Todl.Compiler.CodeAnalysis.Syntax
+namespace Todl.Compiler.CodeAnalysis.Syntax;
+
+public abstract class SyntaxNode
 {
-    public abstract class SyntaxNode : IDiagnosable
-    {
-        public SyntaxTree SyntaxTree { get; internal init; }
-        public DiagnosticBag.Builder DiagnosticBuilder { get; internal init; }
-        public abstract TextSpan Text { get; }
-
-        public virtual IEnumerable<Diagnostic> GetDiagnostics()
-        {
-            if (DiagnosticBuilder == null)
-            {
-                return DiagnosticBag.Empty;
-            }
-
-            return DiagnosticBuilder.Build();
-        }
-    }
+    public SyntaxTree SyntaxTree { get; internal init; }
+    public abstract TextSpan Text { get; }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
+using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
 
@@ -19,10 +20,13 @@ public sealed class SyntaxTree
     public ImmutableArray<Member> Members => parser.Members;
     public ClrTypeCacheView ClrTypeCacheView { get; private set; }
 
-    internal SyntaxTree(SourceText sourceText, ClrTypeCache clrTypeCache)
+    internal SyntaxTree(
+        SourceText sourceText,
+        ClrTypeCache clrTypeCache,
+        DiagnosticBag.Builder diagnosticBuilder)
     {
         lexer = new Lexer() { SourceText = sourceText };
-        parser = new Parser(this);
+        parser = new Parser(this, diagnosticBuilder);
 
         SourceText = sourceText;
         ClrTypeCache = clrTypeCache;
@@ -50,23 +54,32 @@ public sealed class SyntaxTree
         ClrTypeCacheView = ClrTypeCache.CreateView(Directives.OfType<ImportDirective>());
     }
 
-    public static SyntaxTree Parse(SourceText sourceText, ClrTypeCache clrTypeCache)
+    public static SyntaxTree Parse(
+        SourceText sourceText,
+        ClrTypeCache clrTypeCache,
+        DiagnosticBag.Builder diagnosticBuilder)
     {
-        var syntaxTree = new SyntaxTree(sourceText, clrTypeCache);
+        var syntaxTree = new SyntaxTree(sourceText, clrTypeCache, diagnosticBuilder);
         syntaxTree.Parse();
         return syntaxTree;
     }
 
     // temporarily make available for tests and evaluator
-    internal static Expression ParseExpression(SourceText sourceText, ClrTypeCache clrTypeCache)
+    internal static Expression ParseExpression(
+        SourceText sourceText,
+        ClrTypeCache clrTypeCache,
+        DiagnosticBag.Builder diagnosticBuilder)
     {
-        var syntaxTree = new SyntaxTree(sourceText, clrTypeCache);
+        var syntaxTree = new SyntaxTree(sourceText, clrTypeCache, diagnosticBuilder);
         return syntaxTree.ParseExpression();
     }
 
-    internal static Statement ParseStatement(SourceText sourceText, ClrTypeCache clrTypeCache)
+    internal static Statement ParseStatement(
+        SourceText sourceText,
+        ClrTypeCache clrTypeCache,
+        DiagnosticBag.Builder diagnosticBuilder)
     {
-        var syntaxTree = new SyntaxTree(sourceText, clrTypeCache);
+        var syntaxTree = new SyntaxTree(sourceText, clrTypeCache, diagnosticBuilder);
         return syntaxTree.ParseStatement();
     }
 }

--- a/src/Todl.Compiler/CodeGeneration/Compilation.cs
+++ b/src/Todl.Compiler/CodeGeneration/Compilation.cs
@@ -50,7 +50,7 @@ public sealed class Compilation : IDisposable, IDiagnosable
 
         ClrTypeCache = ClrTypeCache.FromAssemblies(metadataLoadContext.GetAssemblies(), metadataLoadContext.CoreAssembly);
 
-        var syntaxTrees = sourceTexts.Select(s => SyntaxTree.Parse(s, ClrTypeCache));
+        var syntaxTrees = sourceTexts.Select(s => SyntaxTree.Parse(s, ClrTypeCache, diagnosticBuilder));
         MainModule = BoundModule.Create(ClrTypeCache, syntaxTrees.ToImmutableList());
 
         if (MainModule.EntryPoint is null)

--- a/src/Todl.Compiler/Evaluation/Evaluator.cs
+++ b/src/Todl.Compiler/Evaluation/Evaluator.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
+using System.Runtime.InteropServices;
 using Todl.Compiler.CodeAnalysis;
 using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 using Todl.Compiler.CodeAnalysis.Symbols;
@@ -12,8 +12,6 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.Evaluation
 {
-    using Binder = CodeAnalysis.Binding.BoundTree.Binder;
-
     /// <summary>
     /// An evaluator evaluates expressions and statements and give out results as output
     /// </summary>
@@ -34,8 +32,9 @@ namespace Todl.Compiler.Evaluation
 
         public EvaluatorResult Evaluate(SourceText sourceText)
         {
-            var expression = SyntaxTree.ParseExpression(sourceText, clrTypeCache);
-            var diagnostics = expression.GetDiagnostics();
+            var diagnosticBuilder = new DiagnosticBag.Builder();
+            var expression = SyntaxTree.ParseExpression(sourceText, clrTypeCache, diagnosticBuilder);
+            var diagnostics = diagnosticBuilder.Build();
 
             if (diagnostics.Any())
             {
@@ -47,7 +46,6 @@ namespace Todl.Compiler.Evaluation
                 };
             }
 
-            var diagnosticBuilder = new DiagnosticBag.Builder();
             var binder = Binder.CreateScriptBinder(clrTypeCache, diagnosticBuilder);
             var boundExpression = binder.BindExpression(expression);
 


### PR DESCRIPTION
Similar to https://github.com/ChrisKXu/todl/pull/109, this PR removes `DiagnosticBag` from `SyntaxNode`s.