### PR TITLE
Remove Diagnostics from BoundModule

### DIFF
--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundConditionalStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundConditionalStatementTests.cs
@@ -114,11 +114,8 @@ public sealed class BoundConditionalStatementTests
                 }
                 b = a + 5;
             }";
-        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
-        boundModule.GetDiagnostics().Should().BeEmpty();
+        var func = TestUtils.BindMember<BoundFunctionMember>(inputText);
 
-        var func = boundModule.EntryPointType.BoundMembers[0].As<BoundFunctionMember>();
         var conditionalStatement = func.Body.Statements[2].As<BoundConditionalStatement>();
         var consequence = conditionalStatement.Consequence.As<BoundBlockStatement>();
         consequence.Scope.Parent.Should().Be(func.FunctionScope);

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionCallExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundFunctionCallExpressionTests.cs
@@ -90,9 +90,8 @@ public sealed class BoundFunctionCallExpressionTests
                 Console.WriteLine();
             }
         ";
-        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
-        boundModule.GetDiagnostics().Should().BeEmpty();
+
+        TestUtils.BindModule(inputText).Should().NotBeNull();
     }
 
     [Fact]
@@ -109,10 +108,8 @@ public sealed class BoundFunctionCallExpressionTests
                 return 0;
             }
         ";
-        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-        boundModule.GetDiagnostics().Should().BeEmpty();
+        TestUtils.BindModule(inputText).Should().NotBeNull();
     }
 
     [Fact]
@@ -129,10 +126,8 @@ public sealed class BoundFunctionCallExpressionTests
                 return 0;
             }
         ";
-        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-        boundModule.GetDiagnostics().Should().BeEmpty();
+        TestUtils.BindModule(inputText).Should().NotBeNull();
     }
 
     [Fact]
@@ -151,9 +146,7 @@ public sealed class BoundFunctionCallExpressionTests
                 return 0;
             }
         ";
-        var syntaxTree = TestUtils.ParseSyntaxTree(inputText);
-        var boundModule = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
 
-        boundModule.GetDiagnostics().Should().BeEmpty();
+        TestUtils.BindModule(inputText).Should().NotBeNull();
     }
 }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/ConstantFoldingTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/ConstantFoldingTests.cs
@@ -4,6 +4,7 @@ using Todl.Compiler.CodeAnalysis.Binding;
 using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.CodeAnalysis.Text;
+using Todl.Compiler.Diagnostics;
 using Xunit;
 
 namespace Todl.Compiler.Tests.CodeAnalysis;
@@ -30,9 +31,10 @@ public sealed class ConstantFoldingTests
     [InlineData("const a = ~10UL;", ~10UL)]
     public void ConstantFoldingUnaryOperatorTest(string inputText, object expectedValue)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, new());
-        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
-        module.GetDiagnostics().Should().BeEmpty();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
+        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, [syntaxTree], diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
 
         var variableMember = module.EntryPointType.Variables.ToList()[^1].As<BoundVariableMember>();
         variableMember.BoundVariableDeclarationStatement.Variable.Constant.Should().Be(true);
@@ -54,9 +56,10 @@ public sealed class ConstantFoldingTests
     [InlineData("const a = -20;", -20)]
     public void BasicConstantFoldingTests(string inputText, object expectedValue)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, new());
-        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
-        module.GetDiagnostics().Should().BeEmpty();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
+        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, [syntaxTree], diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
 
         var variableMember = module.EntryPointType.Variables.ToList()[^1].As<BoundVariableMember>();
         variableMember.BoundVariableDeclarationStatement.Variable.Constant.Should().Be(true);
@@ -76,9 +79,10 @@ public sealed class ConstantFoldingTests
     [InlineData("const a = 10; let b = a + 10; const c = a + b;")]
     public void BasicConstantFoldingNegativeTests(string inputText)
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, new());
-        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
-        module.GetDiagnostics().Should().BeEmpty();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString(inputText), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
+        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, [syntaxTree], diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
 
         var variableMember = module.EntryPointType.Variables.ToList()[^1].As<BoundVariableMember>();
         var boundVariableDeclarationStatement = variableMember.BoundVariableDeclarationStatement;
@@ -88,9 +92,10 @@ public sealed class ConstantFoldingTests
     [Fact]
     public void PartiallyFoldedConstantTests()
     {
-        var syntaxTree = SyntaxTree.Parse(SourceText.FromString("let a = 10 + 10;"), TestDefaults.DefaultClrTypeCache, new());
-        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, new[] { syntaxTree });
-        module.GetDiagnostics().Should().BeEmpty();
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var syntaxTree = SyntaxTree.Parse(SourceText.FromString("let a = 10 + 10;"), TestDefaults.DefaultClrTypeCache, diagnosticBuilder);
+        var module = BoundModule.Create(TestDefaults.DefaultClrTypeCache, [syntaxTree], diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
 
         var statement = module.EntryPointType.Variables.ToList()[^1].As<BoundVariableMember>().BoundVariableDeclarationStatement;
         statement.Variable.Constant.Should().Be(false);

--- a/src/Todl.Compiler.Tests/TestUtils.cs
+++ b/src/Todl.Compiler.Tests/TestUtils.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
+using Todl.Compiler.CodeAnalysis.Binding;
 using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 using Todl.Compiler.CodeAnalysis.Symbols;
 using Todl.Compiler.CodeAnalysis.Syntax;
@@ -76,6 +77,20 @@ internal static class TestUtils
         var boundMember = BindMember<TBoundMember>(inputText, diagnosticBuilder);
         diagnosticBuilder.Build().Should().BeEmpty();
         return boundMember;
+    }
+
+    internal static BoundModule BindModule(string inputText, DiagnosticBag.Builder diagnosticBuilder)
+    {
+        var syntaxTree = ParseSyntaxTree(inputText, diagnosticBuilder);
+        return BoundModule.Create(TestDefaults.DefaultClrTypeCache, [syntaxTree], diagnosticBuilder);
+    }
+
+    internal static BoundModule BindModule(string inputText)
+    {
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var boundModule = BindModule(inputText, diagnosticBuilder);
+        diagnosticBuilder.Build().Should().BeEmpty();
+        return boundModule;
     }
 
     internal static void EmitExpressionAndVerify(string input, params TestInstruction[] expectedInstructions)

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundModule.cs
@@ -7,17 +7,12 @@ using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding;
 
-internal sealed class BoundModule : IDiagnosable
+internal sealed class BoundModule
 {
     public IReadOnlyCollection<SyntaxTree> SyntaxTrees { get; private init; }
     public BoundEntryPointTypeDefinition EntryPointType { get; private init; }
     public BoundFunctionMember EntryPoint => EntryPointType.EntryPointFunctionMember;
     public DiagnosticBag.Builder DiagnosticBuilder { get; private init; }
-
-    public static BoundModule Create(
-        ClrTypeCache clrTypeCache,
-        IReadOnlyList<SyntaxTree> syntaxTrees)
-        => Create(clrTypeCache, syntaxTrees, new());
 
     public static BoundModule Create(
         ClrTypeCache clrTypeCache,
@@ -48,7 +43,4 @@ internal sealed class BoundModule : IDiagnosable
             DiagnosticBuilder = diagnosticBuilder
         };
     }
-
-    public IEnumerable<Diagnostic> GetDiagnostics()
-        => DiagnosticBuilder.Build();
 }

--- a/src/Todl.Compiler/CodeGeneration/Compilation.cs
+++ b/src/Todl.Compiler/CodeGeneration/Compilation.cs
@@ -51,7 +51,7 @@ public sealed class Compilation : IDisposable, IDiagnosable
         ClrTypeCache = ClrTypeCache.FromAssemblies(metadataLoadContext.GetAssemblies(), metadataLoadContext.CoreAssembly);
 
         var syntaxTrees = sourceTexts.Select(s => SyntaxTree.Parse(s, ClrTypeCache, diagnosticBuilder));
-        MainModule = BoundModule.Create(ClrTypeCache, syntaxTrees.ToImmutableList());
+        MainModule = BoundModule.Create(ClrTypeCache, syntaxTrees.ToImmutableList(), diagnosticBuilder);
 
         if (MainModule.EntryPoint is null)
         {
@@ -77,8 +77,5 @@ public sealed class Compilation : IDisposable, IDiagnosable
     }
 
     public IEnumerable<Diagnostic> GetDiagnostics()
-    {
-        diagnosticBuilder.Add(MainModule);
-        return diagnosticBuilder.Build();
-    }
+        => diagnosticBuilder.Build();
 }


### PR DESCRIPTION
Following https://github.com/ChrisKXu/todl/commit/f014f73af4cd83a8424fd4b7033a3fde8baa65e2, this PR removes `DiagnosticBag`s from `BoundModule`s.