### PR TITLE
experimental: implement LoopLabel parsing

### DIFF
--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundLoopStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundLoopStatementTests.cs
@@ -105,6 +105,24 @@ public sealed class BoundLoopStatementTests
         loop3_2.BoundLoopContext.Parent.Should().Be(loop3_1.BoundLoopContext);
     }
 
+    [Fact]
+    public void LoopLabelsCannotBeReusedInSameScope()
+    {
+        var diagnosticBuilder = new DiagnosticBag.Builder();
+        var boundLoopStatement = TestUtils.BindStatement<BoundBlockStatement>(
+            @"{
+                while true: loop { while true: loop { } }
+            }", diagnosticBuilder);
+        boundLoopStatement.Should().NotBeNull();
+        var diagnostics = diagnosticBuilder.Build();
+        diagnostics.Count().Should().Be(1);
+
+        var diagnostic = diagnostics.First();
+        diagnostic.Level.Should().Be(DiagnosticLevel.Error);
+        diagnostic.ErrorCode.Should().Be(ErrorCode.DuplicateLoopLabel);
+        diagnostic.Message.Should().Be("Duplicate loop label 'loop'");
+    }
+
     [Theory]
     [InlineData("break;")]
     [InlineData("continue;")]

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/SyntaxNodeTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/SyntaxNodeTests.cs
@@ -38,7 +38,8 @@ public sealed class SyntaxNodeTests
             typeof(SyntaxToken),
             typeof(TypeExpression),
             typeof(ArrayRankSpecifier),
-            typeof(ElseClause)
+            typeof(ElseClause),
+            typeof(LoopLabel)
         }).ToHashSet();
 
         var allSyntaxNodeTypes = typeof(Expression)

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
+using Todl.Compiler.Diagnostics;
 using Xunit;
 
 namespace Todl.Compiler.Tests.CodeAnalysis;
@@ -38,12 +39,26 @@ public sealed class WhileUntilStatementTests
 
         whileUntilStatement.WhileOrUntilToken.Kind.Should().Be(expectedSyntaxKind);
         whileUntilStatement.BlockStatement.InnerStatements.Should().BeEmpty();
+        whileUntilStatement.LoopLabel.Should().BeNull();
 
         var condition = whileUntilStatement.ConditionExpression.As<BinaryExpression>();
         condition.Should().NotBeNull();
         condition.Left.As<NameExpression>().Text.ToString().Should().Be("n");
         condition.Operator.Kind.Should().Be(SyntaxKind.EqualsEqualsToken);
         condition.Right.As<LiteralExpression>().Text.ToString().Should().Be("0");
+    }
+
+    [Theory]
+    [InlineData("while n == 0 : l0 { return n; }", "l0")]
+    [InlineData("until n == 0 : LongerLabel { return n; }", "LongerLabel")]
+    public void WhileUntilStatementsCanHaveLoopLabels(string inputText, string label)
+    {
+        var whileUntilStatement = TestUtils.ParseStatement<WhileUntilStatement>(inputText);
+        whileUntilStatement.Should().NotBeNull();
+
+        whileUntilStatement.LoopLabel.Should().NotBeNull();
+        whileUntilStatement.LoopLabel.Label.As<NameExpression>().Text.Should().Be(label);
+        whileUntilStatement.LoopLabel.ColonToken.Kind.Should().Be(SyntaxKind.ColonToken);
     }
 
     [Theory]

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/Binder.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/Binder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Todl.Compiler.CodeAnalysis.Symbols;
+using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Binding.BoundTree;
@@ -69,11 +70,11 @@ public partial class Binder
             Scope = Scope.CreateChildScope(BoundScopeKind.Type)
         };
 
-    public Binder CreateLoopBinder()
-        => new LoopBinder(BoundLoopContext?.CreateChildContext() ?? new BoundLoopContext())
+    public Binder CreateLoopBinder(LoopLabel loopLabel)
+        => new LoopBinder(BoundLoopContext?.CreateChildContext(loopLabel) ?? new BoundLoopContext() { LoopLabel = loopLabel })
         {
             Parent = this,
-            Scope = Scope.CreateChildScope(BoundScopeKind.BlockStatement)
+            Scope = Scope.CreateChildScope(BoundScopeKind.BlockStatement),
         };
 
     protected void ReportDiagnostic(Diagnostic diagnostic)

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
@@ -18,7 +18,7 @@ public partial class Binder
 {
     private BoundLoopStatement BindWhileUntilStatement(WhileUntilStatement whileUntilStatement)
     {
-        var loopBinder = CreateLoopBinder();
+        var loopBinder = CreateLoopBinder(whileUntilStatement.LoopLabel);
         var condition = loopBinder.BindExpression(whileUntilStatement.ConditionExpression);
         var body = loopBinder.BindBlockStatementInScope(whileUntilStatement.BlockStatement);
         var negated = whileUntilStatement.WhileOrUntilToken.Kind == SyntaxKind.UntilKeywordToken;

--- a/src/Todl.Compiler/CodeAnalysis/BoundLoopContext.cs
+++ b/src/Todl.Compiler/CodeAnalysis/BoundLoopContext.cs
@@ -1,4 +1,6 @@
-﻿namespace Todl.Compiler.CodeAnalysis;
+﻿using Todl.Compiler.CodeAnalysis.Syntax;
+
+namespace Todl.Compiler.CodeAnalysis;
 
 /// <summary>
 /// The BoundLoopContext is used to help identify information related to a loop structure, such as nested loops
@@ -7,11 +9,14 @@ public sealed class BoundLoopContext
 {
     public BoundLoopContext Parent { get; internal init; }
 
-    public BoundLoopContext CreateChildContext()
+    public LoopLabel LoopLabel { get; internal init; }
+
+    public BoundLoopContext CreateChildContext(LoopLabel loopLabel)
     {
         return new BoundLoopContext()
         {
-            Parent = this
+            Parent = this,
+            LoopLabel = loopLabel
         };
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/WhileUntilStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/WhileUntilStatement.cs
@@ -58,7 +58,7 @@ public sealed partial class Parser
         {
             ReportDiagnostic(new()
             {
-                Message = "",
+                Message = "Invalid loop label. Only simple names are allowed.",
                 ErrorCode = ErrorCode.InvalidLoopLabel,
                 TextLocation = label.Text.GetTextLocation(),
                 Level = DiagnosticLevel.Error

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/WhileUntilStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/WhileUntilStatement.cs
@@ -1,4 +1,5 @@
 ﻿using Todl.Compiler.CodeAnalysis.Text;
+using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
 
@@ -6,10 +7,20 @@ public sealed class WhileUntilStatement : Statement
 {
     public SyntaxToken WhileOrUntilToken { get; internal init; }
     public Expression ConditionExpression { get; internal init; }
+    public LoopLabel LoopLabel { get; internal init; }
     public BlockStatement BlockStatement { get; internal init; }
 
     public override TextSpan Text
         => TextSpan.FromTextSpans(WhileOrUntilToken.Text, BlockStatement.Text);
+}
+
+public sealed class LoopLabel : SyntaxNode
+{
+    public SyntaxToken ColonToken { get; internal init; }
+    public NameExpression Label { get; internal init; }
+
+    public override TextSpan Text
+        => TextSpan.FromTextSpans(ColonToken.Text, Label.Text);
 }
 
 public sealed partial class Parser
@@ -21,12 +32,44 @@ public sealed partial class Parser
                 ? ExpectToken(SyntaxKind.WhileKeywordToken)
                 : ExpectToken(SyntaxKind.UntilKeywordToken);
 
+        var conditionExpression = ParseExpression();
+        var loopLabel = Current.Kind == SyntaxKind.ColonToken
+            ? ParseLoopLabel()
+            : null;
+
+        var blockStatement = ParseBlockStatement();
+
         return new()
         {
             SyntaxTree = syntaxTree,
             WhileOrUntilToken = whileOrUntilToken,
-            ConditionExpression = ParseExpression(),
-            BlockStatement = ParseBlockStatement()
+            ConditionExpression = conditionExpression,
+            LoopLabel = loopLabel,
+            BlockStatement = blockStatement
+        };
+    }
+
+    private LoopLabel ParseLoopLabel()
+    {
+        var colonToken = ExpectToken(SyntaxKind.ColonToken);
+        var label = ParseNameExpression();
+
+        if (!label.IsSimpleName)
+        {
+            ReportDiagnostic(new()
+            {
+                Message = "",
+                ErrorCode = ErrorCode.InvalidLoopLabel,
+                TextLocation = label.Text.GetTextLocation(),
+                Level = DiagnosticLevel.Error
+            });
+        }
+
+        return new()
+        {
+            SyntaxTree = syntaxTree,
+            ColonToken = colonToken,
+            Label = label
         };
     }
 }

--- a/src/Todl.Compiler/Diagnostics/ErrorCode.cs
+++ b/src/Todl.Compiler/Diagnostics/ErrorCode.cs
@@ -33,6 +33,7 @@
         UnreachableCode,
         DuplicateParameterName,
         MissingEntryPoint,
-        NoEnclosingLoop
+        NoEnclosingLoop,
+        DuplicateLoopLabel
     }
 }

--- a/src/Todl.Compiler/Diagnostics/ErrorCode.cs
+++ b/src/Todl.Compiler/Diagnostics/ErrorCode.cs
@@ -14,6 +14,7 @@
         IfUnlessKeywordMismatch,
         DuplicateBareElseClauses,
         MisplacedBareElseClauses,
+        InvalidLoopLabel,
 
         // BinderErrors
         UndeclaredVariable,


### PR DESCRIPTION
This PR introduces the concept of a "loop label" where we can put labels on loops. For example
```
while n > 1 : outer {
    while (m <= 0) : inner {
    }
}
```
this way `break`s and `continue`s inside these loops can explicitly specify which layer of the nest loop it's going to apply to. This removes the need for the infamous `goto` feature.

This PR provides parser and binder support for `LoopLabel`s, and no emit/cfa support.