### PR TITLE
Pin Roslyn build compiler via Microsoft.Net.Compilers.Toolset

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,4 +17,8 @@
     <PublishDir>$(OutDir)\Published</PublishDir>
     <PackageOutputPath>$(OutputRoot)\Packages</PackageOutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="5.3.0" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Problem
After #158 bumped `Microsoft.CodeAnalysis.CSharp` to 5.3.0 in the source generator project, the build fails on machines whose installed SDK bundles an older Roslyn compiler.

A source generator runs *inside* `csc`, and Roslyn refuses to load an analyzer built against a newer compiler than itself:

```
CSC : warning CS9057: Analyzer assembly 'Todl.Compiler.SourceGenerators.dll' cannot be used
because it references version '5.3.0.0' of the compiler, which is newer than the currently
running version '5.0.0.0'.
```

When that happens the generator is skipped, `BoundTreeVisitor` is never generated, and `BoundTreeWalker`/`BoundTreeRewriter` fail with 48x `CS0115: no suitable method found to override`.

This only reproduced on machines with SDK 10.0.101 (csc 5.0). CI uses `setup-dotnet` with `10.0.x`, which pulls the latest patch (Roslyn 5.3+), so it stayed green.

## Fix
- Pin `Microsoft.Net.Compilers.Toolset` 5.3.0 in `Directory.Build.props` so the build always runs a matching Roslyn regardless of the installed SDK. Keep this in sync with `Microsoft.CodeAnalysis.CSharp`.
- Set `global.json` `version` to the canonical `10.0.100` band (there is no 10.0.0 SDK); `rollForward: latestFeature` still rolls up to newer bands.

## Verification
- `dotnet build src` -> 0 warnings, 0 errors
- `dotnet test src` -> 683 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)