### PR TITLE
Caching lexer and parser results after parsing complete

### DIFF
--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -21,7 +21,7 @@ internal sealed class Lexer
     private char Current => Seek(0);
     private char Peak => Seek(1);
 
-    public ImmutableArray<SyntaxToken> SyntaxTokens => syntaxTokens.ToImmutable();
+    public ImmutableArray<SyntaxToken> SyntaxTokens { get; private set; }
 
     private char Seek(int offset)
     {
@@ -526,8 +526,8 @@ internal sealed class Lexer
 
     public void Lex()
     {
-        // if syntaxTokens is not empty, it means lexer has already been executed.
-        if (syntaxTokens.Any())
+        // if position is not 0, it means lexer has already been executed.
+        if (position != 0)
         {
             return;
         }
@@ -541,5 +541,7 @@ internal sealed class Lexer
         }
         while (token.Kind != SyntaxKind.BadToken
             && token.Kind != SyntaxKind.EndOfFileToken);
+
+        SyntaxTokens = syntaxTokens.ToImmutable();
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
@@ -16,6 +16,10 @@ public sealed partial class Parser
     private readonly ImmutableArray<Member>.Builder members
         = ImmutableArray.CreateBuilder<Member>();
 
+    // Immutable collections that will be populated once parsing finishes.
+    public ImmutableArray<Directive> Directives { get; private set; }
+    public ImmutableArray<Member> Members { get; private set; }
+
     private int position = 0;
 
     private ImmutableArray<SyntaxToken> SyntaxTokens => syntaxTree.SyntaxTokens;
@@ -23,8 +27,6 @@ public sealed partial class Parser
     private SyntaxToken Current => Seek(0);
     private SyntaxToken Peak => Seek(1);
 
-    public ImmutableArray<Directive> Directives => directives.ToImmutable();
-    public ImmutableArray<Member> Members => members.ToImmutable();
 
     private SyntaxToken Seek(int offset)
     {
@@ -93,6 +95,10 @@ public sealed partial class Parser
         {
             members.Add(ParseMember());
         }
+
+        // Materialize the immutable collections once parsing is finished.
+        Directives = directives.ToImmutable();
+        Members = members.ToImmutable();
     }
 
     private Expression ParsePrimaryExpression()
@@ -154,7 +160,6 @@ public sealed partial class Parser
 
     private SyntaxToken ReportUnexpectedToken(SyntaxKind expectedSyntaxKind)
     {
-        // return a fake syntax token of the expected kind, with a text span at the current location with 0 length 
         return new()
         {
             Kind = expectedSyntaxKind,


### PR DESCRIPTION
This PR made a performance improvement to allow caching of lexer and parser results, preventing them to be generated multiple times.