### PR TITLE
CLI scaffold: System.CommandLine with command classes

### DIFF
--- a/src/Todl.CommandLine/Commands/BuildCommand.cs
+++ b/src/Todl.CommandLine/Commands/BuildCommand.cs
@@ -1,0 +1,32 @@
+using System;
+using System.CommandLine;
+
+namespace Todl.CommandLine.Commands;
+
+public class BuildCommand : Command
+{
+    public BuildCommand() : base("build", "Build a Todl project")
+    {
+        var outputPathOption = new Option<string>("--output");
+        outputPathOption.Aliases.Add("-o");
+
+        var pathArgument = new Argument<string>("path");
+
+        Add(outputPathOption);
+        Add(pathArgument);
+
+        SetAction((parseResult) =>
+        {
+            var path = parseResult.GetValue(pathArgument);
+            var output = parseResult.GetValue(outputPathOption);
+
+            Console.WriteLine($"stub: build {path}");
+            if (!string.IsNullOrEmpty(output))
+            {
+                Console.WriteLine($"output: {output}");
+            }
+
+            return 0;
+        });
+    }
+}

--- a/src/Todl.CommandLine/Program.cs
+++ b/src/Todl.CommandLine/Program.cs
@@ -1,0 +1,17 @@
+using System.CommandLine;
+using Todl.CommandLine.Commands;
+
+namespace Todl.CommandLine;
+
+public static class Program
+{
+    public static int Run(string[] args)
+    {
+        var rootCommand = new RootCommand("The Todl compiler and build tool");
+
+        rootCommand.Add(new BuildCommand());
+
+        var parseResult = rootCommand.Parse(args);
+        return parseResult.Invoke();
+    }
+}

--- a/src/Todl.CommandLine/Todl.CommandLine.csproj
+++ b/src/Todl.CommandLine/Todl.CommandLine.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/src/Todl.slnx
+++ b/src/Todl.slnx
@@ -4,6 +4,7 @@
   <Project Path="Todl.Compiler.Tests/Todl.Compiler.Tests.csproj" />
   <Project Path="Todl.Compiler.SourceGenerators/Todl.Compiler.SourceGenerators.csproj" />
   <Project Path="Todl.Sdk/Todl.Sdk.csproj" />
+  <Project Path="Todl.CommandLine/Todl.CommandLine.csproj" />
   <Project Path="Todl.Playground/Todl.Playground.csproj" />
   <Folder Name="/Solution Items/">
     <File Path="../.editorconfig" />

--- a/src/Todl/Program.cs
+++ b/src/Todl/Program.cs
@@ -2,10 +2,10 @@
 
 namespace Todl;
 
-static class Program
+class Program
 {
-    static void Main()
+    static int Main(string[] args)
     {
-        Console.WriteLine("Hello Todl!");
+        return CommandLine.Program.Run(args);
     }
 }

--- a/src/Todl/Todl.csproj
+++ b/src/Todl/Todl.csproj
@@ -8,5 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Todl.Compiler\Todl.Compiler.csproj" />
+    <ProjectReference Include="..\Todl.CommandLine\Todl.CommandLine.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add Todl.CommandLine class library project with System.CommandLine 2.0.9
- Extract BuildCommand into separate Command subclass for extensibility
- Update todl main entry point to delegate to Todl.CommandLine.Program.Run()
- Add Todl.CommandLine to solution file