### PR TITLE
Add coordinate + owner-based resolution APIs

### DIFF
--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -1,4 +1,4 @@
-﻿using Todl.Compiler.CodeAnalysis.Text;
+using Todl.Compiler.CodeAnalysis.Text;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
 
@@ -6,4 +6,7 @@ public abstract class SyntaxNode
 {
     public SyntaxTree SyntaxTree { get; internal init; }
     public abstract TextSpan Text { get; }
+
+    public string GetText() => SyntaxTree.SourceText.ToString(Text);
+    public TextLocation GetTextLocation() => new(SyntaxTree.SourceText, Text);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Text/SourceText.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Text/SourceText.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Todl.Compiler.CodeAnalysis.Text
@@ -21,5 +22,10 @@ namespace Todl.Compiler.CodeAnalysis.Text
             };
 
         public TextSpan GetTextSpan(int start, int length) => new(this, start, length);
+        public string ToString(TextSpan span)
+            => Text.Substring(span.Start, span.Length);
+
+        public ReadOnlySpan<char> AsSpan(TextSpan span)
+            => Text.AsSpan(span.Start, span.Length);
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Text/TextLocation.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Text/TextLocation.cs
@@ -1,3 +1,6 @@
-﻿namespace Todl.Compiler.CodeAnalysis.Text;
+namespace Todl.Compiler.CodeAnalysis.Text;
 
-public record struct TextLocation(TextSpan TextSpan);
+public record struct TextLocation(SourceText SourceText, TextSpan TextSpan)
+{
+    public readonly string GetText() => SourceText?.ToString(TextSpan);
+}

--- a/src/Todl.Compiler/CodeAnalysis/Text/TextSpan.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Text/TextSpan.cs
@@ -69,6 +69,11 @@ namespace Todl.Compiler.CodeAnalysis.Text
             return ToReadOnlyTextSpan() == other.AsSpan();
         }
 
+        public static TextSpan FromBounds(int start, int end)
+        {
+            return new TextSpan(null!, start, end - start);
+        }
+
         public TextLocation GetTextLocation() => new() { TextSpan = this };
     }
 }


### PR DESCRIPTION
This PR adds additive-only APIs for position and span-based text resolution:

   * TextSpan.FromBounds(int start, int end) - creates span from bounds
   * SourceText.ToString(TextSpan) / AsSpan(TextSpan) - convenience methods
   * TextLocation converted to record with GetText() support
   * SyntaxNode.GetText() and GetTextLocation() helper methods