### PR TITLE
Detach TextSpan from SourceText

### DIFF
--- a/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundLoopStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/BinderTests/BoundLoopStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Binding.BoundTree;
 using Todl.Compiler.Diagnostics;
@@ -51,7 +51,7 @@ public sealed class BoundLoopStatementTests
         var boundLoopStatement = TestUtils.BindStatement<BoundLoopStatement>("while true: loop { }");
         boundLoopStatement.Should().NotBeNull();
         boundLoopStatement.BoundLoopContext.Should().NotBeNull();
-        boundLoopStatement.BoundLoopContext.LoopLabel.Label.Text.Should().Be("loop");
+        boundLoopStatement.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("loop");
     }
 
     [Fact]
@@ -81,27 +81,27 @@ public sealed class BoundLoopStatementTests
         loops.Should().NotBeNull();
 
         var loop1_1 = loops.Statements[0].As<BoundLoopStatement>();
-        loop1_1.BoundLoopContext.LoopLabel.Label.Text.Should().Be("loop1");
+        loop1_1.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("loop1");
         loop1_1.BoundLoopContext.Parent.Should().BeNull();
         var loop1_2 = loop1_1.Body.As<BoundBlockStatement>().Statements[0].As<BoundLoopStatement>();
-        loop1_2.BoundLoopContext.LoopLabel.Label.Text.Should().Be("loop2");
+        loop1_2.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("loop2");
         loop1_2.BoundLoopContext.Parent.Should().Be(loop1_1.BoundLoopContext);
         var loop1_3 = loop1_2.Body.As<BoundBlockStatement>().Statements[0].As<BoundLoopStatement>();
-        loop1_3.BoundLoopContext.LoopLabel.Label.Text.Should().Be("loop3");
+        loop1_3.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("loop3");
         loop1_3.BoundLoopContext.Parent.Should().Be(loop1_2.BoundLoopContext);
 
         var loop2_1 = loops.Statements[1].As<BoundLoopStatement>();
-        loop2_1.BoundLoopContext.LoopLabel.Label.Text.Should().Be("loop2");
+        loop2_1.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("loop2");
         loop2_1.BoundLoopContext.Parent.Should().BeNull();
         var loop2_2 = loop2_1.Body.As<BoundBlockStatement>().Statements[0].As<BoundLoopStatement>();
-        loop2_2.BoundLoopContext.LoopLabel.Label.Text.Should().Be("loop3");
+        loop2_2.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("loop3");
         loop2_2.BoundLoopContext.Parent.Should().Be(loop2_1.BoundLoopContext);
 
         var loop3_1 = loops.Statements[2].As<BoundLoopStatement>();
         loop3_1.BoundLoopContext.LoopLabel.Should().BeNull();
         loop3_1.BoundLoopContext.Parent.Should().BeNull();
         var loop3_2 = loop3_1.Body.As<BoundBlockStatement>().Statements[0].As<BoundLoopStatement>();
-        loop3_2.BoundLoopContext.LoopLabel.Label.Text.Should().Be("inner");
+        loop3_2.BoundLoopContext.LoopLabel.Label.GetText().Should().Be("inner");
         loop3_2.BoundLoopContext.Parent.Should().Be(loop3_1.BoundLoopContext);
     }
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/LexerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -47,7 +47,7 @@ public sealed partial class LexerTests
     {
         var token = LexSingle(text);
         token.Kind.Should().Be(kind);
-        token.Text.Should().Be(text);
+        token.Text.ToString().Should().Be(text);
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public sealed partial class LexerTests
     {
         var token = LexSingle(text);
         token.Kind.Should().Be(SyntaxKind.StringToken);
-        token.Text.Should().Be(text);
+        token.Text.ToString().Should().Be(text);
     }
 
     [Fact]

--- a/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/NumericLiteralTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/LexerTests/NumericLiteralTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Xunit;
 
@@ -31,7 +31,7 @@ public sealed partial class LexerTests
     {
         var token = LexSingle(text);
         token.Kind.Should().Be(SyntaxKind.NumberToken);
-        token.Text.Should().Be(text);
+        token.Text.ToString().Should().Be(text);
     }
 
     [Theory]
@@ -49,7 +49,7 @@ public sealed partial class LexerTests
     {
         var token = LexSingle(text);
         token.Kind.Should().Be(SyntaxKind.NumberToken);
-        token.Text.Should().Be(text);
+        token.Text.ToString().Should().Be(text);
     }
 
     [Theory]
@@ -68,6 +68,6 @@ public sealed partial class LexerTests
     {
         var token = LexSingle(text);
         token.Kind.Should().Be(SyntaxKind.NumberToken);
-        token.Text.Should().Be(text);
+        token.Text.ToString().Should().Be(text);
     }
 }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/BinaryExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/BinaryExpressionTests.cs
@@ -13,15 +13,15 @@ public sealed class BinaryExpressionTests
 
         binaryExpression.Left.As<BinaryExpression>().Invoking(left =>
         {
-            left.Left.As<LiteralExpression>().Text.Should().Be("1");
-            left.Operator.Text.Should().Be("+");
+            left.Left.As<LiteralExpression>().GetText().Should().Be("1");
+            left.Operator.Text.ToString().Should().Be("+");
             left.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-            left.Right.As<LiteralExpression>().Text.Should().Be("2");
+            left.Right.As<LiteralExpression>().GetText().Should().Be("2");
         }).Should().NotThrow();
 
-        binaryExpression.Operator.Text.Should().Be("+");
+        binaryExpression.Operator.Text.ToString().Should().Be("+");
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-        binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("3");
+        binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("3");
     }
 
     [Fact]
@@ -30,20 +30,20 @@ public sealed class BinaryExpressionTests
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>("1 + 2 * 3 - 4");
 
         var left = binaryExpression.Left.As<BinaryExpression>();
-        left.Left.As<LiteralExpression>().Text.Should().Be("1");
-        left.Operator.Text.Should().Be("+");
+        left.Left.As<LiteralExpression>().GetText().Should().Be("1");
+        left.Operator.Text.ToString().Should().Be("+");
         left.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
 
         left.Right.As<BinaryExpression>().Invoking(multiplication =>
         {
-            multiplication.Left.As<LiteralExpression>().Text.Should().Be("2");
-            multiplication.Operator.Text.Should().Be("*");
+            multiplication.Left.As<LiteralExpression>().GetText().Should().Be("2");
+            multiplication.Operator.Text.ToString().Should().Be("*");
             multiplication.Operator.Kind.Should().Be(SyntaxKind.StarToken);
-            multiplication.Right.As<LiteralExpression>().Text.Should().Be("3");
+            multiplication.Right.As<LiteralExpression>().GetText().Should().Be("3");
 
-            binaryExpression.Operator.Text.Should().Be("-");
+            binaryExpression.Operator.Text.ToString().Should().Be("-");
             binaryExpression.Operator.Kind.Should().Be(SyntaxKind.MinusToken);
-            binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("4");
+            binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("4");
         }).Should().NotThrow();
     }
 
@@ -53,20 +53,20 @@ public sealed class BinaryExpressionTests
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>("1 + 2 * 3 <= 4");
 
         var left = binaryExpression.Left.As<BinaryExpression>();
-        left.Left.As<LiteralExpression>().Text.Should().Be("1");
-        left.Operator.Text.Should().Be("+");
+        left.Left.As<LiteralExpression>().GetText().Should().Be("1");
+        left.Operator.Text.ToString().Should().Be("+");
         left.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
 
         left.Right.As<BinaryExpression>().Invoking(multiplication =>
         {
-            multiplication.Left.As<LiteralExpression>().Text.Should().Be("2");
-            multiplication.Operator.Text.Should().Be("*");
+            multiplication.Left.As<LiteralExpression>().GetText().Should().Be("2");
+            multiplication.Operator.Text.ToString().Should().Be("*");
             multiplication.Operator.Kind.Should().Be(SyntaxKind.StarToken);
-            multiplication.Right.As<LiteralExpression>().Text.Should().Be("3");
+            multiplication.Right.As<LiteralExpression>().GetText().Should().Be("3");
 
-            binaryExpression.Operator.Text.Should().Be("<=");
+            binaryExpression.Operator.Text.ToString().Should().Be("<=");
             binaryExpression.Operator.Kind.Should().Be(SyntaxKind.LessThanOrEqualsToken);
-            binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("4");
+            binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("4");
         }).Should().NotThrow();
     }
 
@@ -79,20 +79,20 @@ public sealed class BinaryExpressionTests
         {
             multiplication.Left.As<ParethesizedExpression>().InnerExpression.As<BinaryExpression>().Invoking(inner =>
             {
-                inner.Left.As<LiteralExpression>().Text.Should().Be("1");
-                inner.Operator.Text.Should().Be("+");
+                inner.Left.As<LiteralExpression>().GetText().Should().Be("1");
+                inner.Operator.Text.ToString().Should().Be("+");
                 inner.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-                inner.Right.As<LiteralExpression>().Text.Should().Be("2");
+                inner.Right.As<LiteralExpression>().GetText().Should().Be("2");
             }).Should().NotThrow();
 
-            multiplication.Operator.Text.Should().Be("*");
+            multiplication.Operator.Text.ToString().Should().Be("*");
             multiplication.Operator.Kind.Should().Be(SyntaxKind.StarToken);
-            multiplication.Right.As<LiteralExpression>().Text.Should().Be("3");
+            multiplication.Right.As<LiteralExpression>().GetText().Should().Be("3");
         }).Should().NotThrow();
 
-        binaryExpression.Operator.Text.Should().Be("-");
+        binaryExpression.Operator.Text.ToString().Should().Be("-");
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.MinusToken);
-        binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("4");
+        binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("4");
     }
 
     [Fact]
@@ -100,16 +100,16 @@ public sealed class BinaryExpressionTests
     {
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>("3 == 1 + 2");
 
-        binaryExpression.Left.Text.Should().Be("3");
-        binaryExpression.Operator.Text.Should().Be("==");
+        binaryExpression.Left.GetText().Should().Be("3");
+        binaryExpression.Operator.Text.ToString().Should().Be("==");
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.EqualsEqualsToken);
 
         binaryExpression.Right.As<BinaryExpression>().Invoking(right =>
         {
-            right.Left.As<LiteralExpression>().Text.Should().Be("1");
-            right.Operator.Text.Should().Be("+");
+            right.Left.As<LiteralExpression>().GetText().Should().Be("1");
+            right.Operator.Text.ToString().Should().Be("+");
             right.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-            right.Right.As<LiteralExpression>().Text.Should().Be("2");
+            right.Right.As<LiteralExpression>().GetText().Should().Be("2");
         }).Should().NotThrow();
     }
 
@@ -118,16 +118,16 @@ public sealed class BinaryExpressionTests
     {
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>("5 != 1 + 2");
 
-        binaryExpression.Left.As<LiteralExpression>().Text.Should().Be("5");
-        binaryExpression.Operator.Text.Should().Be("!=");
+        binaryExpression.Left.As<LiteralExpression>().GetText().Should().Be("5");
+        binaryExpression.Operator.Text.ToString().Should().Be("!=");
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.BangEqualsToken);
 
         binaryExpression.Right.As<BinaryExpression>().Invoking(right =>
         {
-            right.Left.As<LiteralExpression>().Text.Should().Be("1");
-            right.Operator.Text.Should().Be("+");
+            right.Left.As<LiteralExpression>().GetText().Should().Be("1");
+            right.Operator.Text.ToString().Should().Be("+");
             right.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-            right.Right.As<LiteralExpression>().Text.Should().Be("2");
+            right.Right.As<LiteralExpression>().GetText().Should().Be("2");
         }).Should().NotThrow();
     }
 
@@ -142,24 +142,24 @@ public sealed class BinaryExpressionTests
             {
                 inner.Left.As<UnaryExpression>().Invoking(unaryExpression =>
                 {
-                    unaryExpression.Operator.Text.Should().Be("-");
+                    unaryExpression.Operator.Text.ToString().Should().Be("-");
                     unaryExpression.Operator.Kind.Should().Be(SyntaxKind.MinusToken);
-                    unaryExpression.Operand.As<SimpleNameExpression>().Text.Should().Be("a");
+                    unaryExpression.Operand.As<SimpleNameExpression>().GetText().Should().Be("a");
                 }).Should().NotThrow();
 
-                inner.Operator.Text.Should().Be("+");
+                inner.Operator.Text.ToString().Should().Be("+");
                 inner.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-                inner.Right.As<LiteralExpression>().Text.Should().Be("2");
+                inner.Right.As<LiteralExpression>().GetText().Should().Be("2");
             }).Should().NotThrow();
 
-            multiplication.Operator.Text.Should().Be("*");
+            multiplication.Operator.Text.ToString().Should().Be("*");
             multiplication.Operator.Kind.Should().Be(SyntaxKind.StarToken);
-            multiplication.Right.As<LiteralExpression>().Text.Should().Be("3");
+            multiplication.Right.As<LiteralExpression>().GetText().Should().Be("3");
         }).Should().NotThrow();
 
-        binaryExpression.Operator.Text.Should().Be("+");
+        binaryExpression.Operator.Text.ToString().Should().Be("+");
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-        binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("4");
+        binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("4");
     }
 
     [Theory]
@@ -172,10 +172,10 @@ public sealed class BinaryExpressionTests
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>(input);
 
         binaryExpression.Should().NotBeNull();
-        binaryExpression.Left.As<SimpleNameExpression>().Text.Should().Be("a");
-        binaryExpression.Operator.Text.Should().Be(expectedOperatorText);
+        binaryExpression.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
+        binaryExpression.Operator.Text.ToString().Should().Be(expectedOperatorText);
         binaryExpression.Operator.Kind.Should().Be(expectedKind);
-        binaryExpression.Right.As<SimpleNameExpression>().Text.Should().Be("b");
+        binaryExpression.Right.As<SimpleNameExpression>().GetText().Should().Be("b");
     }
 
     [Theory]
@@ -188,10 +188,10 @@ public sealed class BinaryExpressionTests
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>(input);
 
         binaryExpression.Should().NotBeNull();
-        binaryExpression.Left.As<SimpleNameExpression>().Text.Should().Be("a");
-        binaryExpression.Operator.Text.Should().Be(expectedOperatorText);
+        binaryExpression.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
+        binaryExpression.Operator.Text.ToString().Should().Be(expectedOperatorText);
         binaryExpression.Operator.Kind.Should().Be(expectedKind);
-        binaryExpression.Right.As<SimpleNameExpression>().Text.Should().Be("b");
+        binaryExpression.Right.As<SimpleNameExpression>().GetText().Should().Be("b");
     }
 
     [Fact]
@@ -200,10 +200,10 @@ public sealed class BinaryExpressionTests
         var binaryExpression = TestUtils.ParseExpression<BinaryExpression>("10 / 2");
 
         binaryExpression.Should().NotBeNull();
-        binaryExpression.Left.As<LiteralExpression>().Text.Should().Be("10");
-        binaryExpression.Operator.Text.Should().Be("/");
+        binaryExpression.Left.As<LiteralExpression>().GetText().Should().Be("10");
+        binaryExpression.Operator.Text.ToString().Should().Be("/");
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.SlashToken);
-        binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("2");
+        binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("2");
     }
 
     [Fact]
@@ -218,13 +218,13 @@ public sealed class BinaryExpressionTests
 
         var left = binaryExpression.Left.As<BinaryExpression>();
         left.Operator.Kind.Should().Be(SyntaxKind.AmpersandAmpersandToken);
-        left.Left.As<SimpleNameExpression>().Text.Should().Be("a");
-        left.Right.As<SimpleNameExpression>().Text.Should().Be("b");
+        left.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
+        left.Right.As<SimpleNameExpression>().GetText().Should().Be("b");
 
         var right = binaryExpression.Right.As<BinaryExpression>();
         right.Operator.Kind.Should().Be(SyntaxKind.AmpersandAmpersandToken);
-        right.Left.As<SimpleNameExpression>().Text.Should().Be("c");
-        right.Right.As<SimpleNameExpression>().Text.Should().Be("d");
+        right.Left.As<SimpleNameExpression>().GetText().Should().Be("c");
+        right.Right.As<SimpleNameExpression>().GetText().Should().Be("d");
     }
 
     [Fact]
@@ -236,12 +236,12 @@ public sealed class BinaryExpressionTests
 
         binaryExpression.Should().NotBeNull();
         binaryExpression.Operator.Kind.Should().Be(SyntaxKind.PipeToken);
-        binaryExpression.Left.As<SimpleNameExpression>().Text.Should().Be("a");
+        binaryExpression.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
 
         var right = binaryExpression.Right.As<BinaryExpression>();
         right.Operator.Kind.Should().Be(SyntaxKind.AmpersandToken);
-        right.Left.As<SimpleNameExpression>().Text.Should().Be("b");
-        right.Right.As<SimpleNameExpression>().Text.Should().Be("c");
+        right.Left.As<SimpleNameExpression>().GetText().Should().Be("b");
+        right.Right.As<SimpleNameExpression>().GetText().Should().Be("c");
     }
 
     [Fact]

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/BlockStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/BlockStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Xunit;
 
@@ -18,7 +18,7 @@ public sealed class BlockStatementTests
             ";
         var blockStatement = TestUtils.ParseStatement<BlockStatement>(inputText);
 
-        blockStatement.OpenBraceToken.Text.Should().Be("{");
+        blockStatement.OpenBraceToken.Text.ToString().Should().Be("{");
         blockStatement.OpenBraceToken.Kind.Should().Be(SyntaxKind.OpenBraceToken);
 
         blockStatement.InnerStatements.Should().SatisfyRespectively(
@@ -26,7 +26,7 @@ public sealed class BlockStatementTests
             _1 => _1.As<ExpressionStatement>().Should().NotBeNull(),
             _2 => _2.As<ExpressionStatement>().Should().NotBeNull());
 
-        blockStatement.CloseBraceToken.Text.Should().Be("}");
+        blockStatement.CloseBraceToken.Text.ToString().Should().Be("}");
         blockStatement.CloseBraceToken.Kind.Should().Be(SyntaxKind.CloseBraceToken);
     }
 
@@ -41,7 +41,7 @@ public sealed class BlockStatementTests
             ";
         var blockStatement = TestUtils.ParseStatement<BlockStatement>(inputText);
 
-        blockStatement.OpenBraceToken.Text.Should().Be("{");
+        blockStatement.OpenBraceToken.Text.ToString().Should().Be("{");
         blockStatement.OpenBraceToken.Kind.Should().Be(SyntaxKind.OpenBraceToken);
 
         blockStatement.InnerStatements.Should().SatisfyRespectively(
@@ -49,7 +49,7 @@ public sealed class BlockStatementTests
             _1 => _1.As<ExpressionStatement>().Should().NotBeNull(),
             _2 => _2.As<ExpressionStatement>().Should().NotBeNull());
 
-        blockStatement.CloseBraceToken.Text.Should().Be("");
+        blockStatement.CloseBraceToken.Text.ToString().Should().Be("");
         blockStatement.CloseBraceToken.Kind.Should().Be(SyntaxKind.CloseBraceToken);
         blockStatement.CloseBraceToken.Missing.Should().BeTrue();
         //blockStatement.GetDiagnostics().Should().NotBeEmpty();

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionCallExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionCallExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.Diagnostics;
 using Xunit;
@@ -9,13 +9,13 @@ public sealed class FunctionCallExpressionTests
 {
     private void PerformBasicValidationForFunctionCallExpression(FunctionCallExpression functionCallExpression)
     {
-        functionCallExpression.DotToken.Text.Should().Be(".");
+        functionCallExpression.DotToken.Text.ToString().Should().Be(".");
         functionCallExpression.DotToken.Kind.Should().Be(SyntaxKind.DotToken);
         functionCallExpression.NameToken.Kind.Should().Be(SyntaxKind.IdentifierToken);
 
-        functionCallExpression.Arguments.OpenParenthesisToken.Text.Should().Be("(");
+        functionCallExpression.Arguments.OpenParenthesisToken.Text.ToString().Should().Be("(");
         functionCallExpression.Arguments.OpenParenthesisToken.Kind.Should().Be(SyntaxKind.OpenParenthesisToken);
-        functionCallExpression.Arguments.CloseParenthesisToken.Text.Should().Be(")");
+        functionCallExpression.Arguments.CloseParenthesisToken.Text.ToString().Should().Be(")");
         functionCallExpression.Arguments.CloseParenthesisToken.Kind.Should().Be(SyntaxKind.CloseParenthesisToken);
     }
 
@@ -27,8 +27,8 @@ public sealed class FunctionCallExpressionTests
 
         PerformBasicValidationForFunctionCallExpression(functionCallExpression);
 
-        functionCallExpression.BaseExpression.As<SimpleNameExpression>().Text.Should().Be("a");
-        functionCallExpression.NameToken.Text.Should().Be("ToString");
+        functionCallExpression.BaseExpression.As<SimpleNameExpression>().GetText().Should().Be("a");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("ToString");
         functionCallExpression.Arguments.Items.Should().BeEmpty();
     }
 
@@ -40,14 +40,14 @@ public sealed class FunctionCallExpressionTests
 
         PerformBasicValidationForFunctionCallExpression(functionCallExpression);
 
-        functionCallExpression.BaseExpression.As<NamespaceQualifiedNameExpression>().Text.Should().Be("System::Int32");
-        functionCallExpression.NameToken.Text.Should().Be("Parse");
+        functionCallExpression.BaseExpression.As<NamespaceQualifiedNameExpression>().GetText().Should().Be("System::Int32");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Parse");
 
         functionCallExpression.Arguments.Items.Should().NotBeEmpty();
         functionCallExpression.Arguments.Items.Should().SatisfyRespectively(argument =>
         {
             argument.IsNamedArgument.Should().Be(false);
-            argument.Expression.As<LiteralExpression>().Text.Should().Be("\"123\"");
+            argument.Expression.As<LiteralExpression>().GetText().Should().Be("\"123\"");
         });
     }
 
@@ -59,18 +59,18 @@ public sealed class FunctionCallExpressionTests
 
         PerformBasicValidationForFunctionCallExpression(functionCallExpression);
 
-        functionCallExpression.BaseExpression.As<NamespaceQualifiedNameExpression>().Text.Should().Be("System::Int32");
-        functionCallExpression.NameToken.Text.Should().Be("Parse");
+        functionCallExpression.BaseExpression.As<NamespaceQualifiedNameExpression>().GetText().Should().Be("System::Int32");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Parse");
 
         functionCallExpression.Arguments.Items.Should().NotBeEmpty();
         functionCallExpression.Arguments.Items.Should().SatisfyRespectively(argument =>
         {
             argument.IsNamedArgument.Should().Be(true);
-            argument.Identifier?.Text.Should().Be("s");
+            argument.Identifier?.Text.ToString().Should().Be("s");
             argument.Identifier?.Kind.Should().Be(SyntaxKind.IdentifierToken);
-            argument.ColonToken?.Text.Should().Be(":");
+            argument.ColonToken?.Text.ToString().Should().Be(":");
             argument.ColonToken?.Kind.Should().Be(SyntaxKind.ColonToken);
-            argument.Expression.As<LiteralExpression>().Text.Should().Be("\"123\"");
+            argument.Expression.As<LiteralExpression>().GetText().Should().Be("\"123\"");
         });
     }
 
@@ -92,7 +92,7 @@ public sealed class FunctionCallExpressionTests
 
         PerformBasicValidationForFunctionCallExpression(functionCallExpression);
 
-        functionCallExpression.NameToken.Text.Should().Be("Format");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Format");
         functionCallExpression.Arguments.Items.Should().HaveCount(4);
 
         functionCallExpression.Arguments.Items.Should().SatisfyRespectively(
@@ -104,17 +104,17 @@ public sealed class FunctionCallExpressionTests
             arg1 =>
             {
                 arg1.IsNamedArgument.Should().BeFalse();
-                arg1.Expression.As<SimpleNameExpression>().Text.Should().Be("a");
+                arg1.Expression.As<SimpleNameExpression>().GetText().Should().Be("a");
             },
             arg2 =>
             {
                 arg2.IsNamedArgument.Should().BeFalse();
-                arg2.Expression.As<SimpleNameExpression>().Text.Should().Be("b");
+                arg2.Expression.As<SimpleNameExpression>().GetText().Should().Be("b");
             },
             arg3 =>
             {
                 arg3.IsNamedArgument.Should().BeFalse();
-                arg3.Expression.As<SimpleNameExpression>().Text.Should().Be("c");
+                arg3.Expression.As<SimpleNameExpression>().GetText().Should().Be("c");
             });
     }
 
@@ -126,24 +126,24 @@ public sealed class FunctionCallExpressionTests
 
         PerformBasicValidationForFunctionCallExpression(functionCallExpression);
 
-        functionCallExpression.NameToken.Text.Should().Be("Method");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Method");
         functionCallExpression.Arguments.Items.Should().HaveCount(3);
 
         functionCallExpression.Arguments.Items.Should().SatisfyRespectively(
             arg0 =>
             {
                 arg0.IsNamedArgument.Should().BeTrue();
-                arg0.Identifier?.Text.Should().Be("first");
+                arg0.Identifier?.Text.ToString().Should().Be("first");
             },
             arg1 =>
             {
                 arg1.IsNamedArgument.Should().BeTrue();
-                arg1.Identifier?.Text.Should().Be("second");
+                arg1.Identifier?.Text.ToString().Should().Be("second");
             },
             arg2 =>
             {
                 arg2.IsNamedArgument.Should().BeTrue();
-                arg2.Identifier?.Text.Should().Be("third");
+                arg2.Identifier?.Text.ToString().Should().Be("third");
             });
     }
 
@@ -154,7 +154,7 @@ public sealed class FunctionCallExpressionTests
         var functionCallExpression = TestUtils.ParseExpression<FunctionCallExpression>(inputText);
 
         functionCallExpression.Should().NotBeNull();
-        functionCallExpression.NameToken.Text.Should().Be("Max");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Max");
         functionCallExpression.Arguments.Items.Should().HaveCount(2);
 
         functionCallExpression.Arguments.Items[0].Expression.Should().BeOfType<BinaryExpression>();
@@ -168,13 +168,13 @@ public sealed class FunctionCallExpressionTests
         var functionCallExpression = TestUtils.ParseExpression<FunctionCallExpression>(inputText);
 
         functionCallExpression.Should().NotBeNull();
-        functionCallExpression.NameToken.Text.Should().Be("ToUpper");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("ToUpper");
         functionCallExpression.Arguments.Items.Should().BeEmpty();
 
         var innerCall = functionCallExpression.BaseExpression.As<FunctionCallExpression>();
         innerCall.Should().NotBeNull();
-        innerCall.NameToken.Text.Should().Be("ToString");
-        innerCall.BaseExpression.As<SimpleNameExpression>().Text.Should().Be("a");
+        innerCall.NameToken.Text.ToString().Should().Be("ToString");
+        innerCall.BaseExpression.As<SimpleNameExpression>().GetText().Should().Be("a");
     }
 
     [Fact]
@@ -184,15 +184,15 @@ public sealed class FunctionCallExpressionTests
         var functionCallExpression = TestUtils.ParseExpression<FunctionCallExpression>(inputText);
 
         functionCallExpression.Should().NotBeNull();
-        functionCallExpression.NameToken.Text.Should().Be("Third");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Third");
 
         var second = functionCallExpression.BaseExpression.As<FunctionCallExpression>();
-        second.NameToken.Text.Should().Be("Second");
+        second.NameToken.Text.ToString().Should().Be("Second");
 
         var first = second.BaseExpression.As<FunctionCallExpression>();
-        first.NameToken.Text.Should().Be("First");
+        first.NameToken.Text.ToString().Should().Be("First");
 
-        first.BaseExpression.As<SimpleNameExpression>().Text.Should().Be("a");
+        first.BaseExpression.As<SimpleNameExpression>().GetText().Should().Be("a");
     }
 
     [Fact]
@@ -202,11 +202,11 @@ public sealed class FunctionCallExpressionTests
         var functionCallExpression = TestUtils.ParseExpression<FunctionCallExpression>(inputText);
 
         functionCallExpression.Should().NotBeNull();
-        functionCallExpression.NameToken.Text.Should().Be("Call");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Call");
         functionCallExpression.Arguments.Items.Should().HaveCount(1);
 
         var innerCall = functionCallExpression.Arguments.Items[0].Expression.As<FunctionCallExpression>();
-        innerCall.NameToken.Text.Should().Be("GetValue");
+        innerCall.NameToken.Text.ToString().Should().Be("GetValue");
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public sealed class FunctionCallExpressionTests
         var functionCallExpression = TestUtils.ParseExpression<FunctionCallExpression>(inputText);
 
         functionCallExpression.Should().NotBeNull();
-        functionCallExpression.NameToken.Text.Should().Be("Abs");
+        functionCallExpression.NameToken.Text.ToString().Should().Be("Abs");
         functionCallExpression.BaseExpression.Should().BeOfType<NamespaceQualifiedNameExpression>();
         functionCallExpression.Arguments.Items.Should().HaveCount(1);
     }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionDeclarationMemberTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/FunctionDeclarationMemberTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Xunit;
 
@@ -11,8 +11,8 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("int Function() {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("int");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("int");
             function.Parameters.Items.Should().BeEmpty();
             function.Body.InnerStatements.Should().BeEmpty();
         }
@@ -22,8 +22,8 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("System::Uri Function() {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("System::Uri");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("System::Uri");
             function.Parameters.Items.Should().BeEmpty();
             function.Body.InnerStatements.Should().BeEmpty();
         }
@@ -33,8 +33,8 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("int[] Function() {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("int[]");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("int[]");
             function.ReturnType.IsArrayType.Should().BeTrue();
             function.Parameters.Items.Should().BeEmpty();
             function.Body.InnerStatements.Should().BeEmpty();
@@ -45,14 +45,14 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("void Function(int a) {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("void");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("void");
             function.Parameters.Items.Should().HaveCount(1);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var a = function.Parameters.Items[0];
-            a.ParameterType.Text.Should().Be("int");
-            a.Identifier.Text.Should().Be("a");
+            a.ParameterType.GetText().Should().Be("int");
+            a.Identifier.Text.ToString().Should().Be("a");
         }
 
         [Fact]
@@ -60,18 +60,18 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("void Function(int a, System::Uri b) {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("void");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("void");
             function.Parameters.Items.Should().HaveCount(2);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var a = function.Parameters.Items[0];
-            a.ParameterType.Text.Should().Be("int");
-            a.Identifier.Text.Should().Be("a");
+            a.ParameterType.GetText().Should().Be("int");
+            a.Identifier.Text.ToString().Should().Be("a");
 
             var b = function.Parameters.Items[1];
-            b.ParameterType.Text.Should().Be("System::Uri");
-            b.Identifier.Text.Should().Be("b");
+            b.ParameterType.GetText().Should().Be("System::Uri");
+            b.Identifier.Text.ToString().Should().Be("b");
         }
 
         [Fact]
@@ -79,19 +79,19 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("void Function(string[] a, System::Uri[] b) {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("void");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("void");
             function.Parameters.Items.Should().HaveCount(2);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var a = function.Parameters.Items[0];
-            a.ParameterType.Text.Should().Be("string[]");
-            a.Identifier.Text.Should().Be("a");
+            a.ParameterType.GetText().Should().Be("string[]");
+            a.Identifier.Text.ToString().Should().Be("a");
             a.ParameterType.IsArrayType.Should().BeTrue();
 
             var b = function.Parameters.Items[1];
-            b.ParameterType.Text.Should().Be("System::Uri[]");
-            b.Identifier.Text.Should().Be("b");
+            b.ParameterType.GetText().Should().Be("System::Uri[]");
+            b.Identifier.Text.ToString().Should().Be("b");
             b.ParameterType.IsArrayType.Should().BeTrue();
         }
 
@@ -100,24 +100,24 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var function = TestUtils.ParseMember<FunctionDeclarationMember>("void Function(int intParameter, string[] stringArrayParameter, System::Uri[][] twoDimensionalArraysParameter) {}");
             function.Should().NotBeNull();
-            function.Name.Text.Should().Be("Function");
-            function.ReturnType.Text.Should().Be("void");
+            function.Name.Text.ToString().Should().Be("Function");
+            function.ReturnType.GetText().Should().Be("void");
             function.Parameters.Items.Should().HaveCount(3);
             function.Body.InnerStatements.Should().BeEmpty();
 
             var intParameter = function.Parameters.Items[0];
-            intParameter.ParameterType.Text.Should().Be("int");
-            intParameter.Identifier.Text.Should().Be(nameof(intParameter));
+            intParameter.ParameterType.GetText().Should().Be("int");
+            intParameter.Identifier.Text.ToString().Should().Be(nameof(intParameter));
             intParameter.ParameterType.IsArrayType.Should().BeFalse();
 
             var stringArrayParameter = function.Parameters.Items[1];
-            stringArrayParameter.ParameterType.Text.Should().Be("string[]");
-            stringArrayParameter.Identifier.Text.Should().Be(nameof(stringArrayParameter));
+            stringArrayParameter.ParameterType.GetText().Should().Be("string[]");
+            stringArrayParameter.Identifier.Text.ToString().Should().Be(nameof(stringArrayParameter));
             stringArrayParameter.ParameterType.IsArrayType.Should().BeTrue();
 
             var twoDimensionalArraysParameter = function.Parameters.Items[2];
-            twoDimensionalArraysParameter.ParameterType.Text.Should().Be("System::Uri[][]");
-            twoDimensionalArraysParameter.Identifier.Text.Should().Be(nameof(twoDimensionalArraysParameter));
+            twoDimensionalArraysParameter.ParameterType.GetText().Should().Be("System::Uri[][]");
+            twoDimensionalArraysParameter.Identifier.Text.ToString().Should().Be(nameof(twoDimensionalArraysParameter));
             twoDimensionalArraysParameter.ParameterType.IsArrayType.Should().BeTrue();
         }
 
@@ -126,10 +126,10 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var emptyReturnStatement = TestUtils.ParseStatement<ReturnStatement>("return;");
             emptyReturnStatement.Should().NotBeNull();
-            emptyReturnStatement.ReturnKeywordToken.Text.Should().Be("return");
+            emptyReturnStatement.ReturnKeywordToken.Text.ToString().Should().Be("return");
             emptyReturnStatement.ReturnKeywordToken.Kind.Should().Be(SyntaxKind.ReturnKeywordToken);
             emptyReturnStatement.ReturnValueExpression.Should().BeNull();
-            emptyReturnStatement.SemicolonToken.Text.Should().Be(";");
+            emptyReturnStatement.SemicolonToken.Text.ToString().Should().Be(";");
             emptyReturnStatement.SemicolonToken.Kind.Should().Be(SyntaxKind.SemicolonToken);
         }
 
@@ -138,24 +138,24 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var returnStatement = TestUtils.ParseStatement<ReturnStatement>("return (1 + 2) * 4;");
             returnStatement.Should().NotBeNull();
-            returnStatement.ReturnKeywordToken.Text.Should().Be("return");
+            returnStatement.ReturnKeywordToken.Text.ToString().Should().Be("return");
             returnStatement.ReturnKeywordToken.Kind.Should().Be(SyntaxKind.ReturnKeywordToken);
-            returnStatement.SemicolonToken.Text.Should().Be(";");
+            returnStatement.SemicolonToken.Text.ToString().Should().Be(";");
             returnStatement.SemicolonToken.Kind.Should().Be(SyntaxKind.SemicolonToken);
 
             returnStatement.ReturnValueExpression.As<BinaryExpression>().Invoking(binaryExpression =>
             {
                 binaryExpression.Left.As<ParethesizedExpression>().InnerExpression.As<BinaryExpression>().Invoking(inner =>
                 {
-                    inner.Left.As<LiteralExpression>().Text.Should().Be("1");
-                    inner.Operator.Text.Should().Be("+");
+                    inner.Left.As<LiteralExpression>().GetText().Should().Be("1");
+                    inner.Operator.Text.ToString().Should().Be("+");
                     inner.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-                    inner.Right.As<LiteralExpression>().Text.Should().Be("2");
+                    inner.Right.As<LiteralExpression>().GetText().Should().Be("2");
                 }).Should().NotThrow();
 
-                binaryExpression.Operator.Text.Should().Be("*");
+                binaryExpression.Operator.Text.ToString().Should().Be("*");
                 binaryExpression.Operator.Kind.Should().Be(SyntaxKind.StarToken);
-                binaryExpression.Right.As<LiteralExpression>().Text.Should().Be("4");
+                binaryExpression.Right.As<LiteralExpression>().GetText().Should().Be("4");
             }).Should().NotThrow();
         }
     }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/IfUnlessStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/IfUnlessStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.Diagnostics;
@@ -23,9 +23,9 @@ public sealed class IfUnlessStatementTests
         var condition = ifUnlessStatement.ConditionExpression.As<BinaryExpression>();
         condition.Should().NotBeNull();
 
-        condition.Left.As<SimpleNameExpression>().Text.ToString().Should().Be("n");
+        condition.Left.As<SimpleNameExpression>().GetText().Should().Be("n");
         condition.Operator.Kind.Should().Be(SyntaxKind.EqualsEqualsToken);
-        condition.Right.As<LiteralExpression>().Text.ToString().Should().Be("0");
+        condition.Right.As<LiteralExpression>().GetText().Should().Be("0");
     }
 
     [Theory]
@@ -55,9 +55,9 @@ public sealed class IfUnlessStatementTests
         var condition = ifUnlessStatement.ConditionExpression.As<ParethesizedExpression>().InnerExpression.As<BinaryExpression>();
         condition.Should().NotBeNull();
 
-        condition.Left.As<SimpleNameExpression>().Text.ToString().Should().Be("n");
+        condition.Left.As<SimpleNameExpression>().GetText().Should().Be("n");
         condition.Operator.Kind.Should().Be(SyntaxKind.EqualsEqualsToken);
-        condition.Right.As<LiteralExpression>().Text.ToString().Should().Be("0");
+        condition.Right.As<LiteralExpression>().GetText().Should().Be("0");
     }
 
     [Theory]
@@ -71,7 +71,7 @@ public sealed class IfUnlessStatementTests
         ifUnlessStatement.ElseClauses.Should().HaveCount(1);
         ifUnlessStatement.ElseClauses[0].BlockStatement.InnerStatements.Should().HaveCount(1);
         var returnStatement = ifUnlessStatement.ElseClauses[0].BlockStatement.InnerStatements[0].As<ReturnStatement>();
-        returnStatement.ReturnValueExpression.Text.Should().Be("0");
+        returnStatement.ReturnValueExpression.GetText().Should().Be("0");
     }
 
     [Theory]
@@ -109,7 +109,7 @@ public sealed class IfUnlessStatementTests
         var duplicateBareElseClauses = diagnostics.First(d => d.ErrorCode == ErrorCode.DuplicateBareElseClauses);
         duplicateBareElseClauses.Should().NotBeNull();
         duplicateBareElseClauses.Level.Should().Be(DiagnosticLevel.Error);
-        duplicateBareElseClauses.TextLocation.TextSpan.ToString().Should().Be("else");
+        duplicateBareElseClauses.TextLocation.GetText().Should().Be("else");
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public sealed class IfUnlessStatementTests
         var misplacedBareElseClauses = diagnostics.First(d => d.ErrorCode == ErrorCode.MisplacedBareElseClauses);
         misplacedBareElseClauses.Should().NotBeNull();
         misplacedBareElseClauses.Level.Should().Be(DiagnosticLevel.Error);
-        misplacedBareElseClauses.TextLocation.TextSpan.ToString().Should().Be("else");
+        misplacedBareElseClauses.TextLocation.GetText().Should().Be("else");
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public sealed class IfUnlessStatementTests
         var ifUnlessKeywordMismatch = diagnostics.First(d => d.ErrorCode == ErrorCode.IfUnlessKeywordMismatch);
         ifUnlessKeywordMismatch.Should().NotBeNull();
         ifUnlessKeywordMismatch.Level.Should().Be(DiagnosticLevel.Error);
-        ifUnlessKeywordMismatch.TextLocation.TextSpan.ToString().Should().Be("unless");
+        ifUnlessKeywordMismatch.TextLocation.GetText().Should().Be("unless");
     }
 
     [Fact]
@@ -161,9 +161,9 @@ public sealed class IfUnlessStatementTests
 
         condition.Left.As<BinaryExpression>().Invoking(left =>
         {
-            left.Left.As<SimpleNameExpression>().Text.Should().Be("a");
+            left.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
             left.Operator.Kind.Should().Be(SyntaxKind.EqualsEqualsToken);
-            left.Right.As<LiteralExpression>().Text.Should().Be("0");
+            left.Right.As<LiteralExpression>().GetText().Should().Be("0");
         }).Should().NotThrow();
 
         condition.Operator.Kind.Should().Be(SyntaxKind.AmpersandAmpersandToken);

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/NameExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/NameExpressionTests.cs
@@ -97,7 +97,7 @@ public sealed class NameExpressionTests
     {
         var name = TestUtils.ParseExpression<NamespaceQualifiedNameExpression>("System::Console");
 
-        name.Text.ToString().Should().Be("System::Console");
+        name.GetText().Should().Be("System::Console");
     }
 
     #endregion

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/NewExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/NewExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Xunit;
 
@@ -8,12 +8,12 @@ public sealed class NewExpressionTests
 {
     private void PerformBasicValidationForNewExpression(NewExpression newExpression)
     {
-        newExpression.NewKeywordToken.Text.Should().Be("new");
+        newExpression.NewKeywordToken.Text.ToString().Should().Be("new");
         newExpression.NewKeywordToken.Kind.Should().Be(SyntaxKind.NewKeywordToken);
 
-        newExpression.Arguments.OpenParenthesisToken.Text.Should().Be("(");
+        newExpression.Arguments.OpenParenthesisToken.Text.ToString().Should().Be("(");
         newExpression.Arguments.OpenParenthesisToken.Kind.Should().Be(SyntaxKind.OpenParenthesisToken);
-        newExpression.Arguments.CloseParenthesisToken.Text.Should().Be(")");
+        newExpression.Arguments.CloseParenthesisToken.Text.ToString().Should().Be(")");
         newExpression.Arguments.CloseParenthesisToken.Kind.Should().Be(SyntaxKind.CloseParenthesisToken);
     }
 
@@ -24,7 +24,7 @@ public sealed class NewExpressionTests
         var newExpression = TestUtils.ParseExpression<NewExpression>(inputText);
 
         PerformBasicValidationForNewExpression(newExpression);
-        newExpression.TypeNameExpression.Text.Should().Be("System::Exception");
+        newExpression.TypeNameExpression.GetText().Should().Be("System::Exception");
         newExpression.Arguments.Items.Should().BeEmpty();
     }
 
@@ -35,11 +35,11 @@ public sealed class NewExpressionTests
         var newExpression = TestUtils.ParseExpression<NewExpression>(inputText);
 
         PerformBasicValidationForNewExpression(newExpression);
-        newExpression.TypeNameExpression.Text.Should().Be("System::Uri");
+        newExpression.TypeNameExpression.GetText().Should().Be("System::Uri");
         newExpression.Arguments.Items.Should().SatisfyRespectively(argument =>
         {
             argument.IsNamedArgument.Should().BeFalse();
-            argument.Expression.As<LiteralExpression>().Text.Should().Be("\"https://google.com\"");
+            argument.Expression.As<LiteralExpression>().GetText().Should().Be("\"https://google.com\"");
         });
     }
 
@@ -50,12 +50,12 @@ public sealed class NewExpressionTests
         var newExpression = TestUtils.ParseExpression<NewExpression>(inputText);
 
         PerformBasicValidationForNewExpression(newExpression);
-        newExpression.TypeNameExpression.Text.Should().Be("System::Uri");
+        newExpression.TypeNameExpression.GetText().Should().Be("System::Uri");
         newExpression.Arguments.Items.Should().SatisfyRespectively(argument =>
         {
             argument.IsNamedArgument.Should().BeTrue();
-            argument.Identifier?.Text.Should().Be("uriString");
-            argument.Expression.As<LiteralExpression>().Text.Should().Be("\"https://google.com\"");
+            argument.Identifier?.Text.ToString().Should().Be("uriString");
+            argument.Expression.As<LiteralExpression>().GetText().Should().Be("\"https://google.com\"");
         });
     }
 
@@ -66,18 +66,18 @@ public sealed class NewExpressionTests
         var newExpression = TestUtils.ParseExpression<NewExpression>(inputText);
 
         PerformBasicValidationForNewExpression(newExpression);
-        newExpression.TypeNameExpression.Text.Should().Be("System::Uri");
+        newExpression.TypeNameExpression.GetText().Should().Be("System::Uri");
 
         newExpression.Arguments.Items.Should().SatisfyRespectively(
             _0 =>
             {
                 _0.IsNamedArgument.Should().BeFalse();
-                _0.Expression.As<LiteralExpression>().Text.Should().Be("\"https://google.com\"");
+                _0.Expression.As<LiteralExpression>().GetText().Should().Be("\"https://google.com\"");
             },
             _1 =>
             {
                 _1.IsNamedArgument.Should().BeFalse();
-                _1.Expression.As<LiteralExpression>().Text.Should().Be("false");
+                _1.Expression.As<LiteralExpression>().GetText().Should().Be("false");
             });
     }
 
@@ -88,20 +88,20 @@ public sealed class NewExpressionTests
         var newExpression = TestUtils.ParseExpression<NewExpression>(inputText);
 
         PerformBasicValidationForNewExpression(newExpression);
-        newExpression.TypeNameExpression.Text.Should().Be("System::Uri");
+        newExpression.TypeNameExpression.GetText().Should().Be("System::Uri");
 
         newExpression.Arguments.Items.Should().SatisfyRespectively(
             uriString =>
             {
                 uriString.IsNamedArgument.Should().BeTrue();
-                uriString.Identifier?.Text.Should().Be("uriString");
-                uriString.Expression.As<LiteralExpression>().Text.Should().Be("\"https://google.com\"");
+                uriString.Identifier?.Text.ToString().Should().Be("uriString");
+                uriString.Expression.As<LiteralExpression>().GetText().Should().Be("\"https://google.com\"");
             },
             dontEscape =>
             {
                 dontEscape.IsNamedArgument.Should().BeTrue();
-                dontEscape.Identifier?.Text.Should().Be("dontEscape");
-                dontEscape.Expression.As<LiteralExpression>().Text.Should().Be("false");
+                dontEscape.Identifier?.Text.ToString().Should().Be("dontEscape");
+                dontEscape.Expression.As<LiteralExpression>().GetText().Should().Be("false");
             });
     }
 }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/ParserTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/ParserTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.CodeAnalysis.Text;
@@ -19,23 +19,23 @@ namespace Todl.Compiler.Tests.CodeAnalysis
         {
             var assignmentExpression = TestUtils.ParseExpression<AssignmentExpression>($"a {expectedOperatorToken} (b + 3) * 2");
 
-            assignmentExpression.Left.As<SimpleNameExpression>().Text.Should().Be("a");
-            assignmentExpression.AssignmentOperator.Text.Should().Be(expectedOperatorToken);
+            assignmentExpression.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
+            assignmentExpression.AssignmentOperator.Text.ToString().Should().Be(expectedOperatorToken);
             assignmentExpression.AssignmentOperator.Kind.Should().Be(expectedTokenKind);
 
             assignmentExpression.Right.As<BinaryExpression>().Invoking(expression =>
             {
                 expression.Left.As<ParethesizedExpression>().InnerExpression.As<BinaryExpression>().Invoking(innerExpression =>
                 {
-                    innerExpression.Left.As<SimpleNameExpression>().Text.Should().Be("b");
-                    innerExpression.Operator.Text.Should().Be("+");
+                    innerExpression.Left.As<SimpleNameExpression>().GetText().Should().Be("b");
+                    innerExpression.Operator.Text.ToString().Should().Be("+");
                     innerExpression.Operator.Kind.Should().Be(SyntaxKind.PlusToken);
-                    innerExpression.Right.As<LiteralExpression>().LiteralToken.Text.Should().Be("3");
+                    innerExpression.Right.As<LiteralExpression>().LiteralToken.Text.ToString().Should().Be("3");
                 }).Should().NotThrow();
 
-                expression.Operator.Text.Should().Be("*");
+                expression.Operator.Text.ToString().Should().Be("*");
                 expression.Operator.Kind.Should().Be(SyntaxKind.StarToken);
-                expression.Right.As<LiteralExpression>().Text.Should().Be("2");
+                expression.Right.As<LiteralExpression>().GetText().Should().Be("2");
             }).Should().NotThrow();
         }
 
@@ -49,7 +49,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             memberAccessExpression.Should().NotBeNull();
 
             var memberName = inputText[(inputText.LastIndexOf('.') + 1)..^0];
-            memberAccessExpression.MemberIdentifierToken.Text.Should().Be(memberName);
+            memberAccessExpression.MemberIdentifierToken.Text.ToString().Should().Be(memberName);
         }
 
         [Fact]
@@ -67,14 +67,14 @@ namespace Todl.Compiler.Tests.CodeAnalysis
                 _0 =>
                 {
                     var constStatement = _0.As<VariableDeclarationStatement>();
-                    constStatement.IdentifierToken.Text.Should().Be("a");
-                    constStatement.InitializerExpression.As<LiteralExpression>().LiteralToken.Text.Should().Be("0");
+                    constStatement.IdentifierToken.Text.ToString().Should().Be("a");
+                    constStatement.InitializerExpression.As<LiteralExpression>().LiteralToken.Text.ToString().Should().Be("0");
                 },
                 _1 =>
                 {
                     var letStatement = _1.As<VariableDeclarationStatement>();
-                    letStatement.IdentifierToken.Text.Should().Be("b");
-                    letStatement.InitializerExpression.As<SimpleNameExpression>().Text.Should().Be("a");
+                    letStatement.IdentifierToken.Text.ToString().Should().Be("b");
+                    letStatement.InitializerExpression.As<SimpleNameExpression>().GetText().Should().Be("a");
                 });
         }
 
@@ -138,10 +138,10 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var expression = TestUtils.ParseExpression<MemberAccessExpression>("System::Console.Out.WriteLine");
 
             expression.Should().NotBeNull();
-            expression.MemberIdentifierToken.Text.Should().Be("WriteLine");
+            expression.MemberIdentifierToken.Text.ToString().Should().Be("WriteLine");
 
             var innerAccess = expression.BaseExpression.As<MemberAccessExpression>();
-            innerAccess.MemberIdentifierToken.Text.Should().Be("Out");
+            innerAccess.MemberIdentifierToken.Text.ToString().Should().Be("Out");
 
             innerAccess.BaseExpression.Should().BeOfType<NamespaceQualifiedNameExpression>();
         }
@@ -153,15 +153,15 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var expression = TestUtils.ParseExpression<AssignmentExpression>("a = b = c = 5");
 
             expression.Should().NotBeNull();
-            expression.Left.As<SimpleNameExpression>().Text.Should().Be("a");
+            expression.Left.As<SimpleNameExpression>().GetText().Should().Be("a");
             expression.AssignmentOperator.Kind.Should().Be(SyntaxKind.EqualsToken);
 
             var inner1 = expression.Right.As<AssignmentExpression>();
-            inner1.Left.As<SimpleNameExpression>().Text.Should().Be("b");
+            inner1.Left.As<SimpleNameExpression>().GetText().Should().Be("b");
 
             var inner2 = inner1.Right.As<AssignmentExpression>();
-            inner2.Left.As<SimpleNameExpression>().Text.Should().Be("c");
-            inner2.Right.As<LiteralExpression>().Text.Should().Be("5");
+            inner2.Left.As<SimpleNameExpression>().GetText().Should().Be("c");
+            inner2.Right.As<LiteralExpression>().GetText().Should().Be("5");
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var expression = TestUtils.ParseExpression<MemberAccessExpression>("\"hello\".Length");
 
             expression.Should().NotBeNull();
-            expression.MemberIdentifierToken.Text.Should().Be("Length");
+            expression.MemberIdentifierToken.Text.ToString().Should().Be("Length");
             expression.BaseExpression.Should().BeOfType<LiteralExpression>();
         }
 
@@ -180,7 +180,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var expression = TestUtils.ParseExpression<MemberAccessExpression>("(a + b).ToString");
 
             expression.Should().NotBeNull();
-            expression.MemberIdentifierToken.Text.Should().Be("ToString");
+            expression.MemberIdentifierToken.Text.ToString().Should().Be("ToString");
             expression.BaseExpression.Should().BeOfType<ParethesizedExpression>();
         }
 
@@ -190,7 +190,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var expression = TestUtils.ParseExpression<MemberAccessExpression>("new System::Object().ToString");
 
             expression.Should().NotBeNull();
-            expression.MemberIdentifierToken.Text.Should().Be("ToString");
+            expression.MemberIdentifierToken.Text.ToString().Should().Be("ToString");
             expression.BaseExpression.Should().BeOfType<NewExpression>();
         }
 
@@ -375,7 +375,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             level1.Should().NotBeNull();
             var level2 = level1.InnerExpression.As<ParethesizedExpression>();
             level2.Should().NotBeNull();
-            level2.InnerExpression.As<SimpleNameExpression>().Text.Should().Be("a");
+            level2.InnerExpression.As<SimpleNameExpression>().GetText().Should().Be("a");
         }
 
         [Fact]
@@ -437,8 +437,8 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var member = TestUtils.ParseMember<VariableDeclarationMember>(input);
 
             member.Should().NotBeNull();
-            member.VariableDeclarationStatement.IdentifierToken.Text.Should().Be(expectedName);
-            member.VariableDeclarationStatement.InitializerExpression.As<LiteralExpression>().Text.Should().Be(expectedValue);
+            member.VariableDeclarationStatement.IdentifierToken.Text.ToString().Should().Be(expectedName);
+            member.VariableDeclarationStatement.InitializerExpression.As<LiteralExpression>().GetText().Should().Be(expectedValue);
         }
 
         [Fact]
@@ -447,7 +447,7 @@ namespace Todl.Compiler.Tests.CodeAnalysis
             var member = TestUtils.ParseMember<VariableDeclarationMember>("const sum = 1 + 2 + 3;");
 
             member.Should().NotBeNull();
-            member.VariableDeclarationStatement.IdentifierToken.Text.Should().Be("sum");
+            member.VariableDeclarationStatement.IdentifierToken.Text.ToString().Should().Be("sum");
             member.VariableDeclarationStatement.InitializerExpression.Should().BeOfType<BinaryExpression>();
         }
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/SyntaxNodeTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/SyntaxNodeTests.cs
@@ -16,7 +16,7 @@ public sealed class SyntaxNodeTests
     [MemberData(nameof(GetAllSyntaxNodesForTest))]
     public void TextShouldBeRepeatable(string inputText, SyntaxNode syntaxNode)
     {
-        syntaxNode.Text.ToString().Should().Be(inputText);
+        syntaxNode.GetText().Should().Be(inputText);
     }
 
     [Theory]

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/UnaryExpressionTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/UnaryExpressionTests.cs
@@ -69,6 +69,6 @@ public sealed class UnaryExpressionTests
 
         unaryExpression.Should().NotBeNull();
         unaryExpression.Operator.Kind.Should().Be(SyntaxKind.TildeToken);
-        unaryExpression.Operand.As<LiteralExpression>().Text.Should().Be("255");
+        unaryExpression.Operand.As<LiteralExpression>().GetText().Should().Be("255");
     }
 }

--- a/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/ParserTests/WhileUntilStatementTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Todl.Compiler.CodeAnalysis.Syntax;
 using Todl.Compiler.Diagnostics;
 using Xunit;
@@ -43,9 +43,9 @@ public sealed class WhileUntilStatementTests
 
         var condition = whileUntilStatement.ConditionExpression.As<BinaryExpression>();
         condition.Should().NotBeNull();
-        condition.Left.As<SimpleNameExpression>().Text.ToString().Should().Be("n");
+        condition.Left.As<SimpleNameExpression>().GetText().Should().Be("n");
         condition.Operator.Kind.Should().Be(SyntaxKind.EqualsEqualsToken);
-        condition.Right.As<LiteralExpression>().Text.ToString().Should().Be("0");
+        condition.Right.As<LiteralExpression>().GetText().Should().Be("0");
     }
 
     [Theory]
@@ -57,7 +57,7 @@ public sealed class WhileUntilStatementTests
         whileUntilStatement.Should().NotBeNull();
 
         whileUntilStatement.LoopLabel.Should().NotBeNull();
-        whileUntilStatement.LoopLabel.Label.As<SimpleNameExpression>().Text.Should().Be(label);
+        whileUntilStatement.LoopLabel.Label.As<SimpleNameExpression>().GetText().Should().Be(label);
         whileUntilStatement.LoopLabel.ColonToken.Kind.Should().Be(SyntaxKind.ColonToken);
     }
 

--- a/src/Todl.Compiler.Tests/CodeAnalysis/Text/TextSpanTests.cs
+++ b/src/Todl.Compiler.Tests/CodeAnalysis/Text/TextSpanTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Todl.Compiler.CodeAnalysis.Text;
+using Xunit;
+
+namespace Todl.Compiler.Tests.CodeAnalysis;
+
+public sealed class TextSpanTests
+{
+    [Fact]
+    public void TextSpansWithEqualCoordinatesAreEqualRegardlessOfOrigin()
+    {
+        // TextSpan is a pure (Start, Length) coordinate: spans carved out of completely
+        // different SourceText instances (old vs. new text) must still compare equal
+        // as long as Start/Length match.
+        var oldSourceText = SourceText.FromString("let a = 1;");
+        var newSourceText = SourceText.FromString("let a = 2; extra");
+
+        var spanFromOld = new TextSpan(4, 1);
+        var spanFromNew = new TextSpan(4, 1);
+
+        spanFromOld.Should().Be(spanFromNew);
+        (spanFromOld == spanFromNew).Should().BeTrue();
+        spanFromOld.GetHashCode().Should().Be(spanFromNew.GetHashCode());
+
+        // The two spans resolve to different text against their respective sources,
+        // which is expected now that resolution is SourceText's responsibility, not TextSpan's.
+        oldSourceText.ToString(spanFromOld).Should().Be("a");
+        newSourceText.ToString(spanFromNew).Should().Be("a");
+    }
+
+    [Fact]
+    public void TextSpansWithDifferentCoordinatesAreNotEqual()
+    {
+        new TextSpan(0, 3).Should().NotBe(new TextSpan(0, 4));
+        new TextSpan(0, 3).Should().NotBe(new TextSpan(1, 3));
+    }
+
+    [Theory]
+    [InlineData(0, 5, 5)]
+    [InlineData(3, 10, 7)]
+    public void EndIsStartPlusLength(int start, int end, int expectedLength)
+    {
+        var span = TextSpan.FromBounds(start, end);
+        span.Start.Should().Be(start);
+        span.Length.Should().Be(expectedLength);
+        span.End.Should().Be(end);
+    }
+}

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/Binder.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/Binder.cs
@@ -80,14 +80,14 @@ public partial class Binder
             while (parent is not null)
             {
                 if (parent.LoopLabel is not null
-                    && parent.LoopLabel.Label.Text.ToString().Equals(loopLabel.Label.Text.ToString()))
+                    && parent.LoopLabel.Label.GetText().Equals(loopLabel.Label.GetText()))
                 {
                     ReportDiagnostic(new Diagnostic()
                     {
                         ErrorCode = ErrorCode.DuplicateLoopLabel,
                         Level = DiagnosticLevel.Error,
-                        TextLocation = loopLabel.Text.GetTextLocation(),
-                        Message = $"Duplicate loop label '{loopLabel.Label.Text}'"
+                        TextLocation = loopLabel.GetTextLocation(),
+                        Message = $"Duplicate loop label '{loopLabel.Label.GetText()}'"
                     });
                 }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundAssignmentExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundAssignmentExpression.cs
@@ -81,7 +81,7 @@ public partial class Binder
                     {
                         Message = $"Variable {variableName} is read-only",
                         Level = DiagnosticLevel.Error,
-                        TextLocation = simpleNameExpression.IdentifierToken.GetTextLocation(),
+                        TextLocation = simpleNameExpression.GetTextLocation(),
                         ErrorCode = ErrorCode.ReadOnlyVariable
                     });
             }
@@ -92,7 +92,7 @@ public partial class Binder
                     {
                         Message = $"Variable {variableName} cannot be assigned to type {right.ResultType}",
                         Level = DiagnosticLevel.Error,
-                        TextLocation = simpleNameExpression.IdentifierToken.GetTextLocation(),
+                        TextLocation = simpleNameExpression.GetTextLocation(),
                         ErrorCode = ErrorCode.TypeMismatch
                     });
             }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBinaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBinaryExpression.cs
@@ -100,7 +100,7 @@ public partial class Binder
                 {
                     Message = $"Operator {binaryExpression.Operator.Text} is not supported on types {boundLeft.ResultType.Name} and {boundRight.ResultType.Name}",
                     Level = DiagnosticLevel.Error,
-                    TextLocation = binaryExpression.Operator.GetTextLocation(),
+                    TextLocation = binaryExpression.GetTextLocation(binaryExpression.Operator.Span),
                     ErrorCode = ErrorCode.UnsupportedOperator
                 });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBreakStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundBreakStatement.cs
@@ -22,7 +22,7 @@ public partial class Binder
                 Level = DiagnosticLevel.Error,
                 ErrorCode = ErrorCode.NoEnclosingLoop,
                 Message = "No enclosing loop out of which to break or continue.",
-                TextLocation = breakStatement.Text.GetTextLocation()
+                TextLocation = breakStatement.GetTextLocation()
             });
         }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundClrFunctionCallExpression.cs
@@ -132,7 +132,7 @@ public partial class Binder
             {
                 Message = $"No matching function '{functionCallExpression.NameToken.Text}' found.",
                 Level = DiagnosticLevel.Error,
-                TextLocation = functionCallExpression.NameToken.Text.GetTextLocation(),
+                TextLocation = functionCallExpression.GetTextLocation(functionCallExpression.NameToken.Span),
                 ErrorCode = ErrorCode.NoMatchingCandidate
             });
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConditionalStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConditionalStatement.cs
@@ -85,18 +85,18 @@ public partial class Binder
     {
         if (boundConditionalStatement.Condition.ResultType.SpecialType != SpecialType.ClrBoolean)
         {
-            var text = boundConditionalStatement.SyntaxNode switch
+            var conditionSyntaxNode = boundConditionalStatement.SyntaxNode switch
             {
-                IfUnlessStatement ifUnlessStatement => ifUnlessStatement.ConditionExpression.Text,
-                ElseClause elseClause => elseClause.ConditionExpression.Text,
-                _ => boundConditionalStatement.SyntaxNode.Text
+                IfUnlessStatement ifUnlessStatement => ifUnlessStatement.ConditionExpression,
+                ElseClause elseClause => elseClause.ConditionExpression,
+                _ => boundConditionalStatement.SyntaxNode
             };
 
             ReportDiagnostic(new Diagnostic()
             {
                 Message = "Condition expressions need to be of boolean type",
                 ErrorCode = ErrorCode.TypeMismatch,
-                TextLocation = text.GetTextLocation(),
+                TextLocation = conditionSyntaxNode.GetTextLocation(),
                 Level = DiagnosticLevel.Error
             });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConstant.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundConstant.cs
@@ -57,7 +57,7 @@ public partial class Binder
 
     private BoundConstant BindNumericConstant(LiteralExpression literalExpression)
     {
-        var text = literalExpression.LiteralToken.Text.ToReadOnlyTextSpan();
+        var text = literalExpression.LiteralToken.Text.Span;
 
         var @base = 10;
         var startIndex = 0;
@@ -102,7 +102,7 @@ public partial class Binder
 
     private BoundConstant BindStringConstant(LiteralExpression literalExpression)
     {
-        var text = literalExpression.LiteralToken.Text.ToReadOnlyTextSpan();
+        var text = literalExpression.LiteralToken.Text.Span;
         var escape = text[0] != '@';
         var builder = new StringBuilder();
 
@@ -153,9 +153,9 @@ public partial class Binder
         ReportDiagnostic(
             new Diagnostic()
             {
-                Message = $"Literal value {literalExpression.Text} is not supported",
+                Message = $"Literal value {literalExpression.GetText()} is not supported",
                 Level = DiagnosticLevel.Error,
-                TextLocation = literalExpression.LiteralToken.GetTextLocation(),
+                TextLocation = literalExpression.GetTextLocation(),
                 ErrorCode = ErrorCode.UnsupportedLiteral
             });
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundContinueStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundContinueStatement.cs
@@ -22,7 +22,7 @@ public partial class Binder
                 Level = DiagnosticLevel.Error,
                 ErrorCode = ErrorCode.NoEnclosingLoop,
                 Message = "No enclosing loop out of which to break or continue.",
-                TextLocation = continueStatement.Text.GetTextLocation()
+                TextLocation = continueStatement.GetTextLocation()
             });
         }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundEntryPointTypeDefinition.cs
@@ -75,7 +75,7 @@ public partial class Binder
                 {
                     Message = "Ambiguous function declaration. Multiple functions with the same name and parameters set are declared within the same scope.",
                     ErrorCode = ErrorCode.AmbiguousFunctionDeclaration,
-                    TextLocation = functionDeclarationMember.Name.Text.GetTextLocation(),
+                    TextLocation = functionDeclarationMember.GetTextLocation(functionDeclarationMember.Name.Span),
                     Level = DiagnosticLevel.Error
                 });
             }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundFunctionMember.cs
@@ -38,7 +38,7 @@ public partial class Binder
                 Message = $"Parameter '{duplicate.First().Name}' is a duplicate",
                 ErrorCode = ErrorCode.DuplicateParameterName,
                 Level = DiagnosticLevel.Error,
-                TextLocation = functionDeclarationMember.Name.GetTextLocation()
+                TextLocation = functionDeclarationMember.GetTextLocation(functionDeclarationMember.Name.Span)
             });
         }
 

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundLoopStatement.cs
@@ -29,7 +29,7 @@ public partial class Binder
             {
                 ErrorCode = ErrorCode.TypeMismatch,
                 Level = DiagnosticLevel.Error,
-                TextLocation = whileUntilStatement.ConditionExpression.Text.GetTextLocation(),
+                TextLocation = whileUntilStatement.ConditionExpression.GetTextLocation(),
                 Message = "Condition must be of boolean type."
             });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
@@ -115,7 +115,7 @@ public partial class Binder
             {
                 Message = $"Member '{memberAccessExpression.MemberIdentifierToken.Text}' does not exist in type '{clrTypeSymbol.ClrType.FullName}'",
                 Level = DiagnosticLevel.Error,
-                TextLocation = memberAccessExpression.MemberIdentifierToken.GetTextLocation(),
+                TextLocation = memberAccessExpression.GetTextLocation(memberAccessExpression.MemberIdentifierToken.Span),
                 ErrorCode = ErrorCode.MemberNotFound
             });
 
@@ -131,7 +131,7 @@ public partial class Binder
             {
                 Message = $"Member {boundMemberAccessExpression.MemberName} is not public.",
                 Level = DiagnosticLevel.Error,
-                TextLocation = boundMemberAccessExpression.SyntaxNode.Text.GetTextLocation(),
+                TextLocation = boundMemberAccessExpression.SyntaxNode.GetTextLocation(),
                 ErrorCode = ErrorCode.MemberNotAccessible
             });
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundNode.cs
@@ -12,6 +12,6 @@ internal abstract class BoundNode
 
     private string GetDebuggerDisplay()
     {
-        return SyntaxNode == null ? GetType().Name : SyntaxNode.Text.ToString();
+        return SyntaxNode == null ? GetType().Name : SyntaxNode.GetText();
     }
 }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundObjectCreationExpression.cs
@@ -111,9 +111,9 @@ public partial class Binder
         ReportDiagnostic(
             new Diagnostic()
             {
-                Message = $"No matching constructor {newExpression.TypeNameExpression.Text} found.",
+                Message = $"No matching constructor {newExpression.TypeNameExpression.GetText()} found.",
                 Level = DiagnosticLevel.Error,
-                TextLocation = newExpression.TypeNameExpression.Text.GetTextLocation(),
+                TextLocation = newExpression.TypeNameExpression.GetTextLocation(),
                 ErrorCode = ErrorCode.NoMatchingCandidate
             });
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundReturnStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundReturnStatement.cs
@@ -36,7 +36,7 @@ public partial class Binder
             {
                 Message = "Return statements are only valid within a function declaration.",
                 ErrorCode = ErrorCode.UnexpectedStatement,
-                TextLocation = returnStatement.Text.GetTextLocation(),
+                TextLocation = returnStatement.GetTextLocation(),
                 Level = DiagnosticLevel.Error
             });
         }
@@ -46,7 +46,7 @@ public partial class Binder
             {
                 Message = $"The function expects a return type of {FunctionSymbol.ReturnType} but {boundReturnStatement.ReturnType} is returned.",
                 ErrorCode = ErrorCode.TypeMismatch,
-                TextLocation = returnStatement.Text.GetTextLocation(),
+                TextLocation = returnStatement.GetTextLocation(),
                 Level = DiagnosticLevel.Error
             });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTypeExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundTypeExpression.cs
@@ -26,9 +26,9 @@ public partial class Binder
             diagnosticBuilder.Add(
                 new Diagnostic()
                 {
-                    Message = $"Type {nameExpression.Text} is invalid",
+                    Message = $"Type {nameExpression.GetText()} is invalid",
                     Level = DiagnosticLevel.Error,
-                    TextLocation = nameExpression.Text.GetTextLocation(),
+                    TextLocation = nameExpression.GetTextLocation(),
                     ErrorCode = ErrorCode.TypeNotFound
                 });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundUnaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundUnaryExpression.cs
@@ -161,7 +161,7 @@ public partial class Binder
                 {
                     Message = $"Unary operator \"{unaryExpression.Operator.Text}\" is not supported on type \"{boundOperand.ResultType.Name}\"",
                     Level = DiagnosticLevel.Error,
-                    TextLocation = unaryExpression.Operator.GetTextLocation(),
+                    TextLocation = unaryExpression.GetTextLocation(unaryExpression.Operator.Span),
                     ErrorCode = ErrorCode.UnsupportedOperator
                 });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/BoundTree/BoundVariableExpression.cs
@@ -41,9 +41,9 @@ public partial class Binder
             ReportDiagnostic(
                 new Diagnostic()
                 {
-                    Message = $"Undeclared variable {simpleNameExpression.Text}",
+                    Message = $"Undeclared variable {simpleNameExpression.GetText()}",
                     Level = DiagnosticLevel.Error,
-                    TextLocation = simpleNameExpression.IdentifierToken.GetTextLocation(),
+                    TextLocation = simpleNameExpression.GetTextLocation(),
                     ErrorCode = ErrorCode.UndeclaredVariable
                 });
         }
@@ -69,7 +69,7 @@ public partial class Binder
                 {
                     Message = $"Type '{NamespaceQualifiedNameExpression.CanonicalName}' could not be found",
                     Level = DiagnosticLevel.Error,
-                    TextLocation = NamespaceQualifiedNameExpression.TypeIdentifierToken.GetTextLocation(),
+                    TextLocation = NamespaceQualifiedNameExpression.GetTextLocation(NamespaceQualifiedNameExpression.TypeIdentifierToken.Span),
                     ErrorCode = ErrorCode.TypeNotFound
                 });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowAnalyzer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowAnalyzer.cs
@@ -44,7 +44,7 @@ internal sealed class ControlFlowAnalyzer : BoundTreeWalker
                 Message = "Not all paths return a value",
                 ErrorCode = ErrorCode.NotAllPathsReturn,
                 Level = DiagnosticLevel.Error,
-                TextLocation = boundFunctionMember.FunctionSymbol.FunctionDeclarationMember.Name.GetTextLocation()
+                TextLocation = boundFunctionMember.FunctionSymbol.FunctionDeclarationMember.GetTextLocation(boundFunctionMember.FunctionSymbol.FunctionDeclarationMember.Name.Span)
             });
         }
     }
@@ -66,7 +66,7 @@ internal sealed class ControlFlowAnalyzer : BoundTreeWalker
                 Message = "Unreachable code",
                 ErrorCode = ErrorCode.UnreachableCode,
                 Level = DiagnosticLevel.Warning,
-                TextLocation = unreachableBlock.Statements[0].SyntaxNode.Text.GetTextLocation()
+                TextLocation = unreachableBlock.Statements[0].SyntaxNode.GetTextLocation()
             });
         }
     }

--- a/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowGraph.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Binding/ControlFlowAnalysis/ControlFlowGraph.cs
@@ -266,7 +266,7 @@ internal sealed class ControlFlowGraph
                 return "[Empty]";
             }
 
-            return Statements[0].SyntaxNode.Text.ToString();
+            return Statements[0].SyntaxNode.GetText();
         }
     }
 

--- a/src/Todl.Compiler/CodeAnalysis/ClrTypeCacheView.cs
+++ b/src/Todl.Compiler/CodeAnalysis/ClrTypeCacheView.cs
@@ -42,7 +42,7 @@ public sealed class ClrTypeCacheView
             return null;
         }
 
-        var resolvedTypeString = typeExpression.Text.ToString().Replace(typeExpression.BaseTypeExpression.Text.ToString(), baseType.Name);
+        var resolvedTypeString = typeExpression.GetText().Replace(typeExpression.BaseTypeExpression.GetText(), baseType.Name);
 
         return new(baseType.ClrType.Assembly.GetType(resolvedTypeString));
     }

--- a/src/Todl.Compiler/CodeAnalysis/Symbols/ClrTypeSymbol.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Symbols/ClrTypeSymbol.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿﻿using System;
 using System.Linq;
 using System.Reflection;
-using Todl.Compiler.CodeAnalysis.Text;
 
 namespace Todl.Compiler.CodeAnalysis.Symbols;
 
@@ -39,7 +38,7 @@ public sealed class ClrTypeSymbol : TypeSymbol
         return false;
     }
 
-    public MemberInfo ResolveMember(TextSpan name)
+    public MemberInfo ResolveMember(ReadOnlyMemory<char> name)
     {
         return ClrType.GetMember(name.ToString()).FirstOrDefault();
     }

--- a/src/Todl.Compiler/CodeAnalysis/Symbols/ReplVariableSymbol.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Symbols/ReplVariableSymbol.cs
@@ -10,7 +10,7 @@ internal sealed class ReplVariableSymbol : VariableSymbol
     public AssignmentExpression AssignmentExpression { get; internal init; }
     public BoundExpression BoundInitializer { get; internal init; }
 
-    public override string Name => AssignmentExpression.Left.Text.ToString();
+    public override string Name => AssignmentExpression.Left.GetText();
     public override bool ReadOnly => false;
     public override TypeSymbol Type => BoundInitializer.ResultType;
 

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/AssignmentExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/AssignmentExpression.cs
@@ -10,7 +10,7 @@ public sealed class AssignmentExpression : Expression
     public SyntaxToken AssignmentOperator { get; internal init; }
     public Expression Right { get; internal init; }
 
-    public override TextSpan Text => TextSpan.FromTextSpans(Left.Text, Right.Text);
+    public override TextSpan Text => TextSpan.FromBounds(Left.Text.Start, Right.Text.End);
 
     public static readonly IReadOnlySet<SyntaxKind> AssignmentOperators
         = ImmutableHashSet.CreateRange(

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/BinaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/BinaryExpression.cs
@@ -10,7 +10,7 @@ public sealed class BinaryExpression : Expression
     public SyntaxToken Operator { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(Left.Text, Right.Text);
+        => TextSpan.FromBounds(Left.Text.Start, Right.Text.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/BlockStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/BlockStatement.cs
@@ -10,7 +10,7 @@ public sealed class BlockStatement : Statement
     public ImmutableArray<Statement> InnerStatements { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(OpenBraceToken.Text, CloseBraceToken.Text);
+        => TextSpan.FromBounds(OpenBraceToken.Span.Start, CloseBraceToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/BreakStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/BreakStatement.cs
@@ -8,7 +8,7 @@ public sealed class BreakStatement : Statement
     public SyntaxToken SemicolonToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(BreakKeywordToken.Text, SemicolonToken.Text);
+        => TextSpan.FromBounds(BreakKeywordToken.Span.Start, SemicolonToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/CommaSeparatedSyntaxList.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/CommaSeparatedSyntaxList.cs
@@ -11,7 +11,7 @@ public sealed class CommaSeparatedSyntaxList<T> : SyntaxNode where T : SyntaxNod
     public SyntaxToken CloseParenthesisToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(OpenParenthesisToken.Text, CloseParenthesisToken.Text);
+        => TextSpan.FromBounds(OpenParenthesisToken.Span.Start, CloseParenthesisToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ContinueStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ContinueStatement.cs
@@ -8,7 +8,7 @@ public sealed class ContinueStatement : Statement
     public SyntaxToken SemicolonToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(ContinueKeywordToken.Text, SemicolonToken.Text);
+        => TextSpan.FromBounds(ContinueKeywordToken.Span.Start, SemicolonToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ExpressionStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ExpressionStatement.cs
@@ -8,7 +8,7 @@ public sealed class ExpressionStatement : Statement
     public SyntaxToken SemicolonToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(Expression.Text, SemicolonToken.Text);
+        => TextSpan.FromBounds(Expression.Text.Start, SemicolonToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionCallExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionCallExpression.cs
@@ -19,7 +19,7 @@ public sealed class Argument : SyntaxNode
         {
             if (IsNamedArgument)
             {
-                return TextSpan.FromTextSpans(Identifier.Value.Text, Expression.Text);
+                return TextSpan.FromBounds(Identifier.Value.Span.Start, Expression.Text.End);
             }
 
             return Expression.Text;
@@ -40,10 +40,10 @@ public sealed class FunctionCallExpression : Expression
         {
             if (BaseExpression != null)
             {
-                return TextSpan.FromTextSpans(BaseExpression.Text, Arguments.Text);
+                return TextSpan.FromBounds(BaseExpression.Text.Start, Arguments.Text.End);
             }
 
-            return TextSpan.FromTextSpans(NameToken.Text, Arguments.Text);
+            return TextSpan.FromBounds(NameToken.Span.Start, Arguments.Text.End);
         }
     }
 }
@@ -81,8 +81,7 @@ public sealed partial class Parser
                 new Diagnostic()
                 {
                     Message = "Either all or none of the arguments should be named arguments",
-                    Level = DiagnosticLevel.Error,
-                    TextLocation = arguments.OpenParenthesisToken.GetTextLocation(),
+                    TextLocation = arguments.GetTextLocation(arguments.OpenParenthesisToken.Span),
                     ErrorCode = ErrorCode.MixedPositionalAndNamedArguments
                 });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionDeclarationMember.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/FunctionDeclarationMember.cs
@@ -8,7 +8,7 @@ public sealed class Parameter : SyntaxNode
     public SyntaxToken Identifier { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(ParameterType.Text, Identifier.Text);
+        => TextSpan.FromBounds(ParameterType.Text.Start, Identifier.Span.End);
 }
 
 public sealed class FunctionDeclarationMember : Member
@@ -18,7 +18,7 @@ public sealed class FunctionDeclarationMember : Member
     public CommaSeparatedSyntaxList<Parameter> Parameters { get; internal init; }
     public BlockStatement Body { get; internal init; }
 
-    public override TextSpan Text => TextSpan.FromTextSpans(ReturnType.Text, Body.Text);
+    public override TextSpan Text => TextSpan.FromBounds(ReturnType.Text.Start, Body.Text.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/IfUnlessStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/IfUnlessStatement.cs
@@ -19,7 +19,7 @@ public sealed class IfUnlessStatement : Statement
     public ImmutableArray<ElseClause> ElseClauses { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(IfOrUnlessToken.Text, BlockStatement.Text);
+        => TextSpan.FromBounds(IfOrUnlessToken.Span.Start, BlockStatement.Text.End);
 }
 
 public sealed class ElseClause : SyntaxNode
@@ -30,7 +30,7 @@ public sealed class ElseClause : SyntaxNode
     public BlockStatement BlockStatement { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(ElseToken.Text, BlockStatement.Text);
+        => TextSpan.FromBounds(ElseToken.Span.Start, BlockStatement.Text.End);
 
     public bool IsBareElseClause => IfOrUnlessToken is null;
 }
@@ -57,7 +57,7 @@ public sealed partial class Parser
                     Message = "if/unless qualifier mismatch",
                     ErrorCode = ErrorCode.IfUnlessKeywordMismatch,
                     Level = DiagnosticLevel.Error,
-                    TextLocation = elseClause.IfOrUnlessToken.Value.GetTextLocation()
+                    TextLocation = elseClause.GetTextLocation(elseClause.IfOrUnlessToken.Value.Span)
                 });
             }
 
@@ -77,7 +77,7 @@ public sealed partial class Parser
                         Message = "bare else clauses must be after all other else clauses",
                         ErrorCode = ErrorCode.MisplacedBareElseClauses,
                         Level = DiagnosticLevel.Error,
-                        TextLocation = b.ElseToken.GetTextLocation()
+                        TextLocation = b.GetTextLocation(b.ElseToken.Span)
                     });
                 }
             }
@@ -91,7 +91,7 @@ public sealed partial class Parser
                         Message = "duplicate bare else clauses",
                         ErrorCode = ErrorCode.DuplicateBareElseClauses,
                         Level = DiagnosticLevel.Error,
-                        TextLocation = b.ElseToken.GetTextLocation()
+                        TextLocation = b.GetTextLocation(b.ElseToken.Span)
                     });
                 }
             }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ImportDirective.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ImportDirective.cs
@@ -36,7 +36,7 @@ public sealed class ImportDirective : Directive
     }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(ImportKeywordToken.Text, SemicolonToken.Text);
+        => TextSpan.FromBounds(ImportKeywordToken.Span.Start, SemicolonToken.Span.End);
 
     internal static int GetHash(IEnumerable<ImportDirective> directives)
     {

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Lexer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
@@ -82,7 +83,7 @@ internal sealed class Lexer
             if (length > 0)
             {
                 triviaList.Add(
-                    new SyntaxTrivia(kind, SourceText.GetTextSpan(start, length)));
+                    new SyntaxTrivia(kind, new TextSpan(start, length), SourceText.Text.AsMemory(start, length)));
             }
 
             start = position;
@@ -501,14 +502,16 @@ internal sealed class Lexer
         var length = this.position - start;
 
         var trailingTrivia = ReadTrailingSyntaxTrivia();
-        var text = SourceText.GetTextSpan(start, length);
+        var span = new TextSpan(start, length);
+        var lexeme = SourceText.Text.AsMemory(start, length);
 
         if (kind == SyntaxKind.BadToken)
         {
             return new()
             {
                 Kind = kind,
-                Text = text,
+                Span = span,
+                Text = lexeme,
                 LeadingTrivia = leadingTrivia,
                 TrailingTrivia = trailingTrivia,
                 ErrorCode = errorCode
@@ -518,7 +521,8 @@ internal sealed class Lexer
         return new()
         {
             Kind = kind,
-            Text = text,
+            Span = span,
+            Text = lexeme,
             LeadingTrivia = leadingTrivia,
             TrailingTrivia = trailingTrivia
         };

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/LiteralExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/LiteralExpression.cs
@@ -5,6 +5,5 @@ namespace Todl.Compiler.CodeAnalysis.Syntax;
 public class LiteralExpression : Expression
 {
     public SyntaxToken LiteralToken { get; internal init; }
-
-    public override TextSpan Text => LiteralToken.Text;
+    public override TextSpan Text => LiteralToken.Span;
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/MemberAccessExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/MemberAccessExpression.cs
@@ -9,5 +9,5 @@ public sealed class MemberAccessExpression : Expression
     public SyntaxToken MemberIdentifierToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(BaseExpression.Text, MemberIdentifierToken.Text);
+        => TextSpan.FromBounds(BaseExpression.Text.Start, MemberIdentifierToken.Span.End);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/NameExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/NameExpression.cs
@@ -29,7 +29,7 @@ public sealed class SimpleNameExpression : NameExpression
 {
     public SyntaxToken IdentifierToken { get; internal init; }
 
-    public override TextSpan Text => IdentifierToken.Text;
+    public override TextSpan Text => IdentifierToken.Span;
     public override string CanonicalName => IdentifierToken.Text.ToString();
     public override SimpleNameExpression GetUnqualifiedName() => this;
 }
@@ -55,7 +55,7 @@ public sealed class NamespaceQualifiedNameExpression : NameExpression
     public SyntaxToken TypeIdentifierToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(NamespaceIdentifiers[0].Text, TypeIdentifierToken.Text);
+        => TextSpan.FromBounds(NamespaceIdentifiers[0].Span.Start, TypeIdentifierToken.Span.End);
 
     public override string CanonicalName
     {

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/NewExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/NewExpression.cs
@@ -10,7 +10,7 @@ public sealed class NewExpression : Expression
     public NameExpression TypeNameExpression { get; internal init; }
     public CommaSeparatedSyntaxList<Argument> Arguments { get; internal init; }
 
-    public override TextSpan Text => TextSpan.FromTextSpans(NewKeywordToken.Text, Arguments.Text);
+    public override TextSpan Text => TextSpan.FromBounds(NewKeywordToken.Span.Start, Arguments.Text.End);
 }
 
 public sealed partial class Parser
@@ -28,8 +28,7 @@ public sealed partial class Parser
                 new Diagnostic()
                 {
                     Message = "Either all or none of the arguments should be named arguments",
-                    Level = DiagnosticLevel.Error,
-                    TextLocation = arguments.OpenParenthesisToken.GetTextLocation(),
+                    TextLocation = arguments.GetTextLocation(arguments.OpenParenthesisToken.Span),
                     ErrorCode = ErrorCode.MixedPositionalAndNamedArguments
                 });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ParethesizedExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ParethesizedExpression.cs
@@ -9,7 +9,7 @@ public sealed class ParethesizedExpression : Expression
     public SyntaxToken RightParenthesisToken { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(LeftParenthesisToken.Text, RightParenthesisToken.Text);
+        => TextSpan.FromBounds(LeftParenthesisToken.Span.Start, RightParenthesisToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/Parser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using Todl.Compiler.CodeAnalysis.Text;
 using Todl.Compiler.Diagnostics;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
@@ -163,7 +164,8 @@ public sealed partial class Parser
         return new()
         {
             Kind = expectedSyntaxKind,
-            Text = syntaxTree.SourceText.GetTextSpan(Current.Text.Start, 0),
+            Span = new TextSpan(Current.Span.Start, 0),
+            Text = ReadOnlyMemory<char>.Empty,
             LeadingTrivia = ImmutableArray<SyntaxTrivia>.Empty,
             TrailingTrivia = ImmutableArray<SyntaxTrivia>.Empty,
             Missing = true,

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/ReturnStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/ReturnStatement.cs
@@ -7,9 +7,8 @@ public sealed class ReturnStatement : Statement
     public SyntaxToken ReturnKeywordToken { get; internal init; }
     public Expression ReturnValueExpression { get; internal init; }
     public SyntaxToken SemicolonToken { get; internal init; }
-
     public override TextSpan Text
-        => TextSpan.FromTextSpans(ReturnKeywordToken.Text, SemicolonToken.Text);
+        => TextSpan.FromBounds(ReturnKeywordToken.Span.Start, SemicolonToken.Span.End);
 }
 
 public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -9,4 +9,5 @@ public abstract class SyntaxNode
 
     public string GetText() => SyntaxTree.SourceText.ToString(Text);
     public TextLocation GetTextLocation() => new(SyntaxTree.SourceText, Text);
+    public TextLocation GetTextLocation(TextSpan span) => new(SyntaxTree.SourceText, span);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxToken.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxToken.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Todl.Compiler.CodeAnalysis.Text;
@@ -9,7 +10,8 @@ namespace Todl.Compiler.CodeAnalysis.Syntax;
 public record struct SyntaxToken
 (
     SyntaxKind Kind,
-    TextSpan Text,
+    TextSpan Span,
+    ReadOnlyMemory<char> Text,
     ImmutableArray<SyntaxTrivia> LeadingTrivia,
     ImmutableArray<SyntaxTrivia> TrailingTrivia,
     bool Missing,
@@ -45,5 +47,11 @@ public record struct SyntaxToken
         };
     }
 
-    public TextLocation GetTextLocation() => new() { TextSpan = Text };
+    /// <summary>
+    /// Builds a TextLocation from this token's Span alone. Tokens carry no reference to their
+    /// originating SyntaxTree/SourceText, so the resulting TextLocation cannot resolve source
+    /// text on its own. Prefer the enclosing SyntaxNode's GetTextLocation(TextSpan) when a
+    /// SourceText-backed TextLocation is required (e.g. for diagnostics).
+    /// </summary>
+    public TextLocation GetTextLocation() => new(default, Span);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTrivia.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/SyntaxTrivia.cs
@@ -1,5 +1,6 @@
-﻿using Todl.Compiler.CodeAnalysis.Text;
+﻿using System;
+using Todl.Compiler.CodeAnalysis.Text;
 
 namespace Todl.Compiler.CodeAnalysis.Syntax;
 
-public readonly record struct SyntaxTrivia(SyntaxKind Kind, TextSpan Text) { }
+public readonly record struct SyntaxTrivia(SyntaxKind Kind, TextSpan Span, ReadOnlyMemory<char> Text) { }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/TypeExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/TypeExpression.cs
@@ -14,7 +14,7 @@ public sealed class TypeExpression : Expression
     public override TextSpan Text
         => !IsArrayType
             ? BaseTypeExpression.Text
-            : TextSpan.FromTextSpans(BaseTypeExpression.Text, ArrayRankSpecifiers[^1].CloseBracketToken.Text);
+            : TextSpan.FromBounds(BaseTypeExpression.Text.Start, ArrayRankSpecifiers[^1].CloseBracketToken.Span.End);
 }
 
 public sealed class ArrayRankSpecifier : SyntaxNode
@@ -22,7 +22,7 @@ public sealed class ArrayRankSpecifier : SyntaxNode
     public SyntaxToken OpenBracketToken { get; internal set; }
     public SyntaxToken CloseBracketToken { get; internal set; }
 
-    public override TextSpan Text => TextSpan.FromTextSpans(OpenBracketToken.Text, CloseBracketToken.Text);
+    public override TextSpan Text => TextSpan.FromBounds(OpenBracketToken.Span.Start, CloseBracketToken.Span.End);
 }
 
 public sealed partial class Parser
@@ -39,6 +39,7 @@ public sealed partial class Parser
 
         return new()
         {
+            SyntaxTree = syntaxTree,
             BaseTypeExpression = nameExpression,
             ArrayRankSpecifiers = arrayRankSpecifiers.ToImmutable()
         };
@@ -47,6 +48,7 @@ public sealed partial class Parser
     private ArrayRankSpecifier ParseArrayRankSpecifier()
         => new()
         {
+            SyntaxTree = syntaxTree,
             OpenBracketToken = ExpectToken(SyntaxKind.OpenBracketToken),
             CloseBracketToken = ExpectToken(SyntaxKind.CloseBracketToken)
         };

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/UnaryExpression.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/UnaryExpression.cs
@@ -7,5 +7,5 @@ public sealed class UnaryExpression : Expression
     public SyntaxToken Operator { get; internal init; }
     public Expression Operand { get; internal init; }
 
-    public override TextSpan Text => TextSpan.FromTextSpans(Operator.Text, Operand.Text);
+    public override TextSpan Text => TextSpan.FromBounds(Operator.Span.Start, Operand.Text.End);
 }

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/VariableDeclarationStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/VariableDeclarationStatement.cs
@@ -14,7 +14,7 @@ namespace Todl.Compiler.CodeAnalysis.Syntax
         public SyntaxToken SemicolonToken { get; internal init; }
 
         public override TextSpan Text
-            => TextSpan.FromTextSpans(DeclarationKeyword.Text, SemicolonToken.Text);
+            => TextSpan.FromBounds(DeclarationKeyword.Span.Start, SemicolonToken.Span.End);
     }
 
     public sealed partial class Parser

--- a/src/Todl.Compiler/CodeAnalysis/Syntax/WhileUntilStatement.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Syntax/WhileUntilStatement.cs
@@ -11,7 +11,7 @@ public sealed class WhileUntilStatement : Statement
     public BlockStatement BlockStatement { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(WhileOrUntilToken.Text, BlockStatement.Text);
+        => TextSpan.FromBounds(WhileOrUntilToken.Span.Start, BlockStatement.Text.End);
 }
 
 public sealed class LoopLabel : SyntaxNode
@@ -20,7 +20,7 @@ public sealed class LoopLabel : SyntaxNode
     public NameExpression Label { get; internal init; }
 
     public override TextSpan Text
-        => TextSpan.FromTextSpans(ColonToken.Text, Label.Text);
+        => TextSpan.FromBounds(ColonToken.Span.Start, Label.Text.End);
 }
 
 public sealed partial class Parser
@@ -58,9 +58,8 @@ public sealed partial class Parser
         {
             ReportDiagnostic(new()
             {
-                Message = "Invalid loop label. Only simple names are allowed.",
+                TextLocation = label.GetTextLocation(),
                 ErrorCode = ErrorCode.InvalidLoopLabel,
-                TextLocation = label.Text.GetTextLocation(),
                 Level = DiagnosticLevel.Error
             });
         }

--- a/src/Todl.Compiler/CodeAnalysis/Text/SourceText.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Text/SourceText.cs
@@ -21,7 +21,6 @@ namespace Todl.Compiler.CodeAnalysis.Text
                 Text = File.ReadAllText(filePath)
             };
 
-        public TextSpan GetTextSpan(int start, int length) => new(this, start, length);
         public string ToString(TextSpan span)
             => Text.Substring(span.Start, span.Length);
 

--- a/src/Todl.Compiler/CodeAnalysis/Text/TextSpan.cs
+++ b/src/Todl.Compiler/CodeAnalysis/Text/TextSpan.cs
@@ -1,79 +1,15 @@
-﻿using System;
-using System.Diagnostics;
-
-namespace Todl.Compiler.CodeAnalysis.Text
+﻿namespace Todl.Compiler.CodeAnalysis.Text
 {
     /// <summary>
-    /// TextSpan represents a portion of the source text
+    /// TextSpan represents a portion of the source text as a pure (Start, Length) coordinate.
+    /// It carries no reference to any particular SourceText instance, so spans with equal
+    /// (Start, Length) compare equal regardless of which source they were produced from.
+    /// Resolving the underlying characters is the responsibility of SourceText/TextLocation.
     /// </summary>
-    public struct TextSpan : IEquatable<TextSpan>, IEquatable<string>
+    public readonly record struct TextSpan(int Start, int Length)
     {
-        public SourceText SourceText { get; }
-        public int Start { get; }
-        public int Length { get; }
         public int End => Start + Length;
 
-        internal TextSpan(SourceText sourceText, int start, int length)
-        {
-            SourceText = sourceText;
-            Start = start;
-            Length = length;
-        }
-
-        public override string ToString()
-        {
-            return SourceText.Text.Substring(Start, Length);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is string other)
-            {
-                return this.ToString().Equals(other);
-            }
-
-            if (obj is TextSpan textSpan)
-            {
-                return Equals(textSpan);
-            }
-
-            return base.Equals(obj);
-        }
-
-        public ReadOnlySpan<char> ToReadOnlyTextSpan()
-        {
-            return SourceText.Text.AsSpan(Start, Length);
-        }
-
-        public static TextSpan FromTextSpans(TextSpan start, TextSpan end)
-        {
-            Debug.Assert(start.SourceText == end.SourceText);
-
-            return start.SourceText.GetTextSpan(start.Start, end.End - start.Start);
-        }
-
-        public bool Equals(TextSpan other)
-        {
-            return SourceText == other.SourceText
-                && Start == other.Start
-                && Length == other.Length;
-        }
-
-        public bool Equals(string other)
-        {
-            return ToReadOnlyTextSpan() == other.AsSpan();
-        }
-
-        public static TextSpan FromBounds(int start, int end)
-        {
-            return new TextSpan(null!, start, end - start);
-        }
-
-        public TextLocation GetTextLocation() => new() { TextSpan = this };
+        public static TextSpan FromBounds(int start, int end) => new(start, end - start);
     }
 }


### PR DESCRIPTION
## Summary

Implements TODL-2: `TextSpan` fused a position (Start/Length) with a reference to the specific `SourceText` it was carved from. This made span equality identity-bound across text versions (same coordinates against two `SourceText` instances were never equal), tethered every span to a `SourceText` for GC, and required a `SourceText` to construct any span.

`TextSpan` is now a bare `(Start, Length)` coordinate, matching the approach used by Roslyn; source association lives on `SourceText`/`SyntaxNode`/`TextLocation`.

## Changes

- `TextSpan` is now a `readonly record struct (Start, Length)` with structural equality, `End`, and `FromBounds`. Dropped the `SourceText` field, `ToString()`, `ToReadOnlyTextSpan()`, and `IEquatable<string>`.
- Text resolution moved to `SourceText.ToString(TextSpan)`/`AsSpan(TextSpan)` and `SyntaxNode.GetText()`/`GetTextLocation()`; added a `GetTextLocation(TextSpan)` overload for diagnostics that need to point at a sub-span within a node (e.g. an operator token inside a binary expression).
- `SyntaxToken`/`SyntaxTrivia` rename their `TextSpan` field to `Span` and add a `ReadOnlyMemory<char> Text` captured at lex time, since tokens carry no tree reference and can't resolve source text on their own.
- Updated all `TextSpan.FromTextSpans` composition sites to `FromBounds`, and all diagnostic sites that previously resolved a `TextLocation` through a bare token or `TextSpan` to go through the enclosing `SyntaxNode` instead.
- Fixed a latent bug in `Parser.ParseTypeExpression`/`ParseArrayRankSpecifier`, which never set `SyntaxTree` on the constructed node — previously masked because `TextSpan` carried its own `SourceText` pointer.
- Updated existing tests for the new resolution API and added `TextSpanTests` covering cross-`SourceText` structural equality.

## Testing

- `dotnet test src/Todl.Compiler.Tests` — 687/687 passing
- `dotnet test src/Todl.CommandLine.Tests` — 20/20 passing
